### PR TITLE
feat(kubeflow): Enable dex-auth static username and password

### DIFF
--- a/modules/kubeflow/README.md
+++ b/modules/kubeflow/README.md
@@ -14,6 +14,8 @@ The solution module offers the following configurable inputs:
 | `cos_configuration`| bool | Boolean value that enables COS configuration | False |
 | `create_model`| bool | Allows to skip Juju model creation and re-use a model created in a higher level module | False |
 | `dex_connectors`| string | dex-auth connectors in yaml format | False |
+| `dex_static_username`| string | dex-auth static username | False |
+| `dex_static_password`| string | dex-auth static password | False |
 | `existing_grafana_agent_name`| string | Name of an existing grafana-agent-k8s deployment | False |
 | `grafana_agent_k8s_size`| string | Grafana agent database storage size | False |
 | `http_proxy`| string | Value of the http_proxy environment variable | False |

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -17,6 +17,8 @@ module "dex_auth" {
   config = {
     "public-url" : var.public_url,
     "connectors" : var.dex_connectors
+    "static-username" : var.dex_static_username
+    "static-password" : var.dex_static_password
   }
   revision = var.dex_auth_revision
 }

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -16,6 +16,18 @@ variable "dex_connectors" {
   default     = ""
 }
 
+variable "dex_static_username" {
+  description = "dex-auth static username value"
+  type        = string
+  default     = ""
+}
+
+variable "dex_static_password" {
+  description = "dex-auth static password"
+  type        = string
+  default     = ""
+}
+
 variable "existing_grafana_agent_name" {
   description = "Name of an existing grafana-agent-k8s deployment"
   type        = string

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -20,14 +20,14 @@ variable "dex_static_username" {
   description = "dex-auth static username value"
   type        = string
   default     = ""
-  sensitive = true
+  sensitive   = true
 }
 
 variable "dex_static_password" {
   description = "dex-auth static password"
   type        = string
   default     = ""
-  sensitive = true
+  sensitive   = true
 }
 
 variable "existing_grafana_agent_name" {

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -20,12 +20,14 @@ variable "dex_static_username" {
   description = "dex-auth static username value"
   type        = string
   default     = ""
+  sensitive = true
 }
 
 variable "dex_static_password" {
   description = "dex-auth static password"
   type        = string
   default     = ""
+  sensitive = true
 }
 
 variable "existing_grafana_agent_name" {


### PR DESCRIPTION
Follow up PR to #2, enabling static username and password variables for Kubeflow solution module. This will omit the need for configuration afterwards (ie [this step](https://charmed-kubeflow.io/docs/install#set-credentials-for-a-static-user)) and enable deployment of the solution like:
```
terraform apply -var dex_static_username="admin" -var dex_static_password="admin"
```

Note that setting those variables to [sensitive](https://developer.hashicorp.com/terraform/language/values/variables#suppressing-values-in-cli-output) hides their values from the CLI print, although they will still be available at the Terraform state file. 
```
  + resource "juju_application" "dex_auth" {
      + config      = {
          + "connectors"      = ""
          + "public-url"      = "http://dex-auth.kubeflow.svc:5556"
          + "static-password" = (sensitive value)
          + "static-username" = (sensitive value)
        }
```
Ref canonical/bundle-kubeflow#1073
