### PR TITLE
fix(ckf): Add outputs dashboard_links_provider and ingress_provider

### DIFF
--- a/modules/kubeflow/README.md
+++ b/modules/kubeflow/README.md
@@ -34,7 +34,9 @@ Upon applied, the solution module exports the following outputs:
 
 | Name | Description |
 | - | - |
+| `dashboard_links_provider`| Map containing the `app_name` and the `provides` endpoint of the dashboard links provider charm |
 | `grafana_agent_k8s`| Map containing the `app_name`, `provides` and `requires` endpoints of the grafana-agent-k8s charm used |
+| `ingress_provider`| Map containing the `app_name` and the `provides` endpoint of the ingress provider charm |
 | `model`|  Model name that Charmed Kubeflow is deployed on |
 | `kserve_controller`|  Map containing the `app_name`, `provides` and `requires` fields of the kserve-controller charm |
 | `tls_certificate_requirer`|  Map containing the `app_name` and the `requires` TLS endpoint of the TLS requirer charm |

--- a/modules/kubeflow/outputs.tf
+++ b/modules/kubeflow/outputs.tf
@@ -1,3 +1,10 @@
+output "dashboard_links_provider" {
+  value = {
+    app_name = module.kubeflow_dashboard.app_name,
+    provides = module.kubeflow_dashboard.provides,
+  }
+}
+
 output "grafana_agent_k8s" {
   value = var.cos_configuration ? {
     app_name = var.existing_grafana_agent_name == null ? one(juju_application.grafana_agent_k8s[*].name) : var.existing_grafana_agent_name
@@ -9,6 +16,13 @@ output "grafana_agent_k8s" {
       send_remote_write = "send-remote-write",
     }
   } : null
+}
+
+output "ingress_provider" {
+  value = {
+    app_name = module.istio_pilot.app_name,
+    provides = module.istio_pilot.provides,
+  }
 }
 
 output "kserve_controller" {


### PR DESCRIPTION
Add outputs dashboard_links_provider and ingress_provider in order to enable integrating MLflow with kubeflow-dashboard and adding its link on the dashboard's left sidebar.

Ref canonical/charmed-mlflow-solutions#6