### PR TITLE
fix(ckf-cmlf): Enable MLflow link in Kubeflow's dashboard

### DIFF
--- a/modules/kubeflow-mlflow/README.md
+++ b/modules/kubeflow-mlflow/README.md
@@ -23,6 +23,7 @@ The solution module offers the following configurable inputs:
 | `katib_db_size`| string | Katib database storage size | False |
 | `kfp_db_size`| string | KFP database storage size | False |
 | `minio_size`| string | MinIO database storage size | False |
+| `mlflow_dashboard_link`| bool | Boolean value that enables MLflow link in Kubeflow's dashboard | False |
 | `mlflow_kserve_integration` | bool | Boolean value that integrates MLflow with KServe | False |
 | `mlflow_minio_size`         | string | MinIO storage size allocation            | False    |
 | `mlflow_mysql_size`  | string | MySQL storage size allocation for MLflow | False    |

--- a/modules/kubeflow-mlflow/integrations.tf
+++ b/modules/kubeflow-mlflow/integrations.tf
@@ -26,6 +26,36 @@ resource "juju_integration" "mlflow_server_resource_dispatcher_pod_defaults" {
   }
 }
 
+resource "juju_integration" "mlflow_server_dashboard_links_provider_links" {
+  count = var.mlflow_dashboard_link ? 1 : 0
+  model = module.kubeflow.model
+
+  application {
+    name     = module.mlflow.mlflow_server.app_name
+    endpoint = module.mlflow.mlflow_server.requires.dashboard_links
+  }
+
+  application {
+    name     = module.kubeflow.dashboard_links_provider.app_name
+    endpoint = module.kubeflow.dashboard_links_provider.provides.links
+  }
+}
+
+resource "juju_integration" "mlflow_server_ingress_provider_ingress" {
+  count = var.mlflow_dashboard_link ? 1 : 0
+  model = module.kubeflow.model
+
+  application {
+    name     = module.mlflow.mlflow_server.app_name
+    endpoint = module.mlflow.mlflow_server.requires.ingress
+  }
+
+  application {
+    name     = module.kubeflow.ingress_provider.app_name
+    endpoint = module.kubeflow.ingress_provider.provides.ingress
+  }
+}
+
 resource "juju_integration" "mlflow_minio_kserve_controller_object_storage" {
   count = var.mlflow_kserve_integration ? 1 : 0
   model = module.kubeflow.model

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -72,6 +72,12 @@ variable "minio_size" {
   default     = "10G"
 }
 
+variable "mlflow_dashboard_link" {
+  description = "Boolean value that enables MLflow link in Kubeflow's dashboard"
+  type        = bool
+  default     = true
+}
+
 variable "mlflow_kserve_integration" {
   description = "Boolean value that enables MLFlow-KServe configuration"
   type        = bool


### PR DESCRIPTION
Enable by default an MLflow link in Kubeflow's dashboard. Can also be turned off with the use of `mlflow_dashboard_link` variable in cases where the user wishes to access MLflow outside the dashboard.

Fix canonical/charmed-mlflow-solutions#6

#### Notes
* Should be merged after #13 . CI will be fixed once the changes from this PR are also included.
* Will be manual tested alongside effort for canonical/charmed-mlflow-solutions#7