### PR TITLE
fix(ckf-cmlf): expose config to enable/disable mlflow nodeport

### DIFF
--- a/modules/kubeflow-mlflow/README.md
+++ b/modules/kubeflow-mlflow/README.md
@@ -15,6 +15,7 @@ The solution module offers the following configurable inputs:
 | `dex_connectors`| string | dex-auth connectors in yaml format | False |
 | `dex_static_username`| string | dex-auth static username | False |
 | `dex_static_password`| string | dex-auth static password | False |
+| `enable_mlflow_nodeport` | bool | Boolean value that enables the NodePort service for MLFlow | False |
 | `grafana_agent_k8s_size`| string | Grafana agent database storage size | False |
 | `http_proxy`| string | Value of the http_proxy environment variable | False |
 | `https_proxy`| string | Value of the https_proxy environment variable | False |

--- a/modules/kubeflow-mlflow/README.md
+++ b/modules/kubeflow-mlflow/README.md
@@ -15,7 +15,7 @@ The solution module offers the following configurable inputs:
 | `dex_connectors`| string | dex-auth connectors in yaml format | False |
 | `dex_static_username`| string | dex-auth static username | False |
 | `dex_static_password`| string | dex-auth static password | False |
-| `enable_mlflow_nodeport` | bool | Boolean value that enables the NodePort service for MLFlow | False |
+| `enable_mlflow_nodeport` | bool | Boolean value that enables the NodePort service for MLflow | False |
 | `grafana_agent_k8s_size`| string | Grafana agent database storage size | False |
 | `http_proxy`| string | Value of the http_proxy environment variable | False |
 | `https_proxy`| string | Value of the https_proxy environment variable | False |

--- a/modules/kubeflow-mlflow/README.md
+++ b/modules/kubeflow-mlflow/README.md
@@ -27,6 +27,7 @@ The solution module offers the following configurable inputs:
 | `mlflow_kserve_integration` | bool | Boolean value that integrates MLflow with KServe | False |
 | `mlflow_minio_size`         | string | MinIO storage size allocation            | False    |
 | `mlflow_mysql_size`  | string | MySQL storage size allocation for MLflow | False    |
+| `mlflow_nodeport` | number | The nodeport for MLflow | False |
 | `mlmd_size`| string | MLMD database storage size | False |
 | `no_proxy`| string | Value of the no_proxy environment variable | False |
 | `public_url`| string | Public URL of Kubeflow for auth/OIDC | False |

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -67,6 +67,7 @@ module "mlflow" {
   mlflow_minio_size           = var.mlflow_minio_size
   mlflow_mysql_revision       = var.mlflow_mysql_revision
   mlflow_mysql_size           = var.mlflow_mysql_size
+  mlflow_nodeport             = var.mlflow_nodeport
   mlflow_server_revision      = var.mlflow_server_revision
 }
 

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -61,6 +61,7 @@ module "mlflow" {
   create_model                = false
   model                       = module.kubeflow.model
   cos_configuration           = var.cos_configuration
+  enable_mlflow_nodeport      = var.enable_mlflow_nodeport
   existing_grafana_agent_name = var.cos_configuration ? module.kubeflow.grafana_agent_k8s.app_name : null
   mlflow_minio_revision       = var.mlflow_minio_revision
   mlflow_minio_size           = var.mlflow_minio_size

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -24,6 +24,12 @@ variable "dex_static_password" {
   sensitive   = true
 }
 
+variable "enable_mlflow_nodeport" {
+  description = "Boolean value that enables the NodePort service for MLFlow"
+  type        = bool
+  default     = true
+}
+
 variable "grafana_agent_k8s_size" {
   description = "Grafana agent database storage size"
   type        = string

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -96,6 +96,12 @@ variable "mlflow_mysql_size" {
   default     = "10G"
 }
 
+variable "mlflow_nodeport" {
+  description = "The nodeport for MLflow"
+  type        = number
+  default     = 31380
+}
+
 variable "mlmd_size" {
   description = "MLMD database storage size"
   type        = string


### PR DESCRIPTION
Ref https://github.com/canonical/charmed-mlflow-solutions/issues/7

Should only be merged after https://github.com/canonical/charmed-mlflow-solutions/pull/9

Exposes the config options `enable_mlflow_nodeport` and `mlflow_nodeport` added in https://github.com/canonical/charmed-mlflow-solutions/pull/9.