### PR TITLE
feat: adding existing_grafana_agent_name variable to kubeflow-mlflow

### DIFF
--- a/modules/kubeflow-mlflow/README.md
+++ b/modules/kubeflow-mlflow/README.md
@@ -17,6 +17,7 @@ The solution module offers the following configurable inputs:
 | `dex_static_username`| string | dex-auth static username | False |
 | `dex_static_password`| string | dex-auth static password | False |
 | `enable_mlflow_nodeport` | bool | Boolean value that enables the NodePort service for MLflow | False |
+| `existing_grafana_agent_name`| string | Name of an existing grafana-agent-k8s deployment | False |
 | `grafana_agent_k8s_size`| string | Grafana agent database storage size | False |
 | `http_proxy`| string | Value of the http_proxy environment variable | False |
 | `https_proxy`| string | Value of the https_proxy environment variable | False |

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -5,6 +5,7 @@ module "kubeflow" {
   dex_connectors                   = var.dex_connectors
   dex_static_username              = var.dex_static_username
   dex_static_password              = var.dex_static_password
+  existing_grafana_agent_name      = var.existing_grafana_agent_name
   grafana_agent_k8s_size           = var.grafana_agent_k8s_size
   http_proxy                       = var.http_proxy
   https_proxy                      = var.https_proxy

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -5,7 +5,7 @@ module "kubeflow" {
   dex_connectors                   = var.dex_connectors
   dex_static_username              = var.dex_static_username
   dex_static_password              = var.dex_static_password
-  existing_grafana_agent_name      = var.cos_configuration ? module.kubeflow.grafana_agent_k8s.app_name : null
+  existing_grafana_agent_name      = var.cos_configuration ? var.existing_grafana_agent_name : null
   grafana_agent_k8s_size           = var.grafana_agent_k8s_size
   http_proxy                       = var.http_proxy
   https_proxy                      = var.https_proxy
@@ -64,7 +64,7 @@ module "mlflow" {
   model                       = module.kubeflow.model
   cos_configuration           = var.cos_configuration
   enable_mlflow_nodeport      = var.enable_mlflow_nodeport
-  existing_grafana_agent_name = var.cos_configuration ? module.kubeflow.grafana_agent_k8s.app_name : null
+  existing_grafana_agent_name = var.cos_configuration ? var.existing_grafana_agent_name : null
   mlflow_minio_revision       = var.mlflow_minio_revision
   mlflow_minio_size           = var.mlflow_minio_size
   mlflow_mysql_revision       = var.mlflow_mysql_revision

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -5,7 +5,7 @@ module "kubeflow" {
   dex_connectors                   = var.dex_connectors
   dex_static_username              = var.dex_static_username
   dex_static_password              = var.dex_static_password
-  existing_grafana_agent_name      = var.existing_grafana_agent_name
+  existing_grafana_agent_name      = var.cos_configuration ? module.kubeflow.grafana_agent_k8s.app_name : null
   grafana_agent_k8s_size           = var.grafana_agent_k8s_size
   http_proxy                       = var.http_proxy
   https_proxy                      = var.https_proxy

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -36,6 +36,12 @@ variable "enable_mlflow_nodeport" {
   default     = true
 }
 
+variable "existing_grafana_agent_name" {
+  description = "Name of an existing grafana-agent-k8s deployment"
+  type        = string
+  default     = null
+}
+
 variable "grafana_agent_k8s_size" {
   description = "Grafana agent database storage size"
   type        = string


### PR DESCRIPTION
The one-click deployment requires also the kubeflow-mlflow bundle to expose the `existing_grafana_agent_name` input variable (that needs to be passed to the kubeflow tf module)