### PR TITLE
[MISC] Risk handling for solutions

### DIFF
--- a/modules/kubeflow-mlflow/README.md
+++ b/modules/kubeflow-mlflow/README.md
@@ -11,6 +11,7 @@ The solution module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `<charm_name>_revision`| number | For each charm of the solution, the revision of the charm to deploy | False |
+| `risk`| string | Value for the risk to be used. Valid values are (stable, candidate, beta and edge) | False |
 | `create_model` | bool | Allows to skip Juju model creation and re-use a model created in a higher level module. When re-using a model, if this is created by Terraform, make sure that the current module depends on the resource using the `depends_on` option. | False |
 | `cos_configuration`| bool | Boolean value that enables COS configuration | False |
 | `dex_connectors`| string | dex-auth connectors in yaml format | False |

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -59,7 +59,7 @@ module "kubeflow" {
 }
 
 module "mlflow" {
-  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=wip-backports"
+  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=track/2.15"
   # kubeflow module creates the model
   create_model                = false
   model                       = module.kubeflow.model

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -1,5 +1,6 @@
 module "kubeflow" {
   source                           = "../kubeflow"
+  risk                             = var.risk
   create_model                     = var.create_model
   cos_configuration                = var.cos_configuration
   dex_connectors                   = var.dex_connectors
@@ -77,4 +78,5 @@ module "resource_dispatcher" {
   source     = "git::https://github.com/canonical/resource-dispatcher//terraform?ref=track/2.0"
   model_name = module.kubeflow.model
   revision   = var.resource_dispatcher_revision
+  channel    = "2.0/${var.risk}"
 }

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -59,7 +59,7 @@ module "kubeflow" {
 }
 
 module "mlflow" {
-  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=wip-new-pinning"
+  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=wip-backports"
   # kubeflow module creates the model
   create_model                = false
   model                       = module.kubeflow.model

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -59,10 +59,11 @@ module "kubeflow" {
 }
 
 module "mlflow" {
-  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=track/2.15"
+  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=wip-new-pinning"
   # kubeflow module creates the model
   create_model                = false
   model                       = module.kubeflow.model
+  risk                        = var.risk
   cos_configuration           = var.cos_configuration
   enable_mlflow_nodeport      = var.enable_mlflow_nodeport
   existing_grafana_agent_name = var.cos_configuration ? module.kubeflow.grafana_agent_k8s.app_name : null

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -6,7 +6,7 @@ variable "risk" {
   validation {
     condition     = contains(["stable", "candidate", "beta", "edge"], var.risk)
     error_message = "Valid values for var: test_variable are (stable, candidate, beta and edge)."
-  } 
+  }
 }
 
 

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -1,3 +1,15 @@
+variable "risk" {
+  type        = string
+  description = "Value for the risk to be used"
+  default     = "stable"
+
+  validation {
+    condition     = contains(["stable", "candidate", "beta", "edge"], var.risk)
+    error_message = "Valid values for var: test_variable are (stable, candidate, beta and edge)."
+  } 
+}
+
+
 variable "create_model" {
   description = "Allows to skip Juju model creation and re-use a model created in a higher level module. When re-using a model, if this is created by Terraform, make sure that the current module depends on the resource using the depends_on option."
   type        = bool

--- a/modules/kubeflow/README.md
+++ b/modules/kubeflow/README.md
@@ -11,6 +11,7 @@ The solution module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `<charm_name>_revision`| number | For each charm of the solution, the revision of the charm to deploy | False |
+| `risk`| string | Value for the risk to be used. Valid values are (stable, candidate, beta and edge) | False |
 | `cos_configuration`| bool | Boolean value that enables COS configuration | False |
 | `create_model`| bool | Allows to skip Juju model creation and re-use a model created in a higher level module | False |
 | `dex_connectors`| string | dex-auth connectors in yaml format | False |

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -3,12 +3,14 @@ module "admission_webhook" {
   source     = "git::https://github.com/canonical/admission-webhook-operator//terraform?ref=track/1.9"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.admission_webhook_revision
+  channel    = "1.9/${var.risk}"
 }
 
 module "argo_controller" {
   source     = "git::https://github.com/canonical/argo-operators//charms/argo-controller/terraform?ref=track/3.4"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.argo_controller_revision
+  channel    = "3.4/${var.risk}"
 }
 
 module "dex_auth" {
@@ -21,12 +23,14 @@ module "dex_auth" {
     "static-password" : var.dex_static_password
   }
   revision = var.dex_auth_revision
+  channel    = "2.39/${var.risk}"
 }
 
 module "envoy" {
   source     = "git::https://github.com/canonical/envoy-operator//terraform?ref=track/2.2"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.envoy_revision
+  channel    = "2.2/${var.risk}"
 }
 
 module "istio_ingressgateway" {
@@ -37,6 +41,7 @@ module "istio_ingressgateway" {
     kind = "ingress",
   }
   revision = var.istio_ingressgateway_revision
+  channel    = "1.22/${var.risk}"
 }
 
 module "istio_pilot" {
@@ -47,12 +52,14 @@ module "istio_pilot" {
     "tls-secret-id" : var.istio_tls_secret_id
   }
   revision = var.istio_pilot_revision
+  channel    = "1.22/${var.risk}"
 }
 
 module "jupyter_controller" {
   source     = "git::https://github.com/canonical/notebook-operators//charms/jupyter-controller/terraform?ref=track/1.9"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.jupyter_controller_revision
+  channel    = "1.9/${var.risk}"
 }
 
 module "jupyter_ui" {
@@ -60,12 +67,14 @@ module "jupyter_ui" {
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   config     = var.jupyter_ui_config
   revision   = var.jupyter_ui_revision
+  channel    = "1.9/${var.risk}"
 }
 
 module "katib_controller" {
   source     = "git::https://github.com/canonical/katib-operators//charms/katib-controller/terraform?ref=track/0.17"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.katib_controller_revision
+  channel    = "0.17/${var.risk}"
 }
 
 module "katib_db" {
@@ -86,18 +95,21 @@ module "katib_db_manager" {
   source     = "git::https://github.com/canonical/katib-operators//charms/katib-db-manager/terraform?ref=track/0.17"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.katib_db_manager_revision
+  channel    = "0.17/${var.risk}"
 }
 
 module "katib_ui" {
   source     = "git::https://github.com/canonical/katib-operators//charms/katib-ui/terraform?ref=track/0.17"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.katib_ui_revision
+  channel    = "0.17/${var.risk}"
 }
 
 module "kfp_api" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-api/terraform?ref=track/2.3"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_api_revision
+  channel    = "2.3/${var.risk}"
 }
 
 module "kfp_db" {
@@ -118,42 +130,49 @@ module "kfp_metadata_writer" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-metadata-writer/terraform?ref=track/2.3"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_metadata_writer_revision
+  channel    = "2.3/${var.risk}"
 }
 
 module "kfp_persistence" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-persistence/terraform?ref=track/2.3"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_persistence_revision
+  channel    = "2.3/${var.risk}"
 }
 
 module "kfp_profile_controller" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-profile-controller/terraform?ref=track/2.3"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_profile_controller_revision
+  channel    = "2.3/${var.risk}"
 }
 
 module "kfp_schedwf" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-schedwf/terraform?ref=track/2.3"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_schedwf_revision
+  channel    = "2.3/${var.risk}"
 }
 
 module "kfp_ui" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-ui/terraform?ref=track/2.3"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_ui_revision
+  channel    = "2.3/${var.risk}"
 }
 
 module "kfp_viewer" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-viewer/terraform?ref=track/2.3"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_viewer_revision
+  channel    = "2.3/${var.risk}"
 }
 
 module "kfp_viz" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-viz/terraform?ref=track/2.3"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_viz_revision
+  channel    = "2.3/${var.risk}"
 }
 
 module "knative_eventing" {
@@ -163,12 +182,14 @@ module "knative_eventing" {
     namespace = "knative-eventing"
   }
   revision = var.knative_eventing_revision
+  channel    = "1.12/${var.risk}"
 }
 
 module "knative_operator" {
   source     = "git::https://github.com/canonical/knative-operators//charms/knative-operator/terraform?ref=track/1.12"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.knative_operator_revision
+  channel    = "1.12/${var.risk}"
 }
 
 module "knative_serving" {
@@ -183,6 +204,7 @@ module "knative_serving" {
     no-proxy                  = var.no_proxy,
   }
   revision = var.knative_serving_revision
+  channel    = "1.12/${var.risk}"
 }
 
 module "kserve_controller" {
@@ -195,36 +217,42 @@ module "kserve_controller" {
     no-proxy        = var.no_proxy,
   }
   revision = var.kserve_controller_revision
+  channel    = "0.13/${var.risk}"
 }
 
 module "kubeflow_dashboard" {
   source     = "git::https://github.com/canonical/kubeflow-dashboard-operator//terraform?ref=track/1.9"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kubeflow_dashboard_revision
+  channel    = "1.9/${var.risk}"
 }
 
 module "kubeflow_profiles" {
   source     = "git::https://github.com/canonical/kubeflow-profiles-operator//terraform?ref=track/1.9"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kubeflow_profiles_revision
+  channel    = "1.9/${var.risk}"
 }
 
 module "kubeflow_roles" {
   source     = "git::https://github.com/canonical/kubeflow-roles-operator//terraform?ref=track/1.9"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kubeflow_roles_revision
+  channel    = "1.9/${var.risk}"
 }
 
 module "kubeflow_volumes" {
   source     = "git::https://github.com/canonical/kubeflow-volumes-operator//terraform?ref=track/1.9"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kubeflow_volumes_revision
+  channel    = "1.9/${var.risk}"
 }
 
 module "metacontroller_operator" {
   source     = "git::https://github.com/canonical/metacontroller-operator//terraform?ref=track/3.0"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.metacontroller_operator_revision
+  channel    = "3.0/${var.risk}"
 }
 
 module "mlmd" {
@@ -234,6 +262,7 @@ module "mlmd" {
     mlmd-data = var.mlmd_size
   }
   revision = var.mlmd_revision
+  channel    = "ckf-1.9/${var.risk}"
 }
 
 module "minio" {
@@ -243,34 +272,40 @@ module "minio" {
     minio-data = var.minio_size
   }
   revision = var.minio_revision
+  channel    = "ckf-1.9/${var.risk}"
 }
 
 module "oidc_gatekeeper" {
   source     = "git::https://github.com/canonical/oidc-gatekeeper-operator//terraform?ref=track/ckf-1.9"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.oidc_gatekeeper_revision
+  channel    = "ckf-1.9/${var.risk}"
 }
 
 module "pvcviewer_operator" {
   source     = "git::https://github.com/canonical/pvcviewer-operator//terraform?ref=track/1.9"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.pvcviewer_operator_revision
+  channel    = "1.9/${var.risk}"
 }
 
 module "tensorboard_controller" {
   source     = "git::https://github.com/canonical/kubeflow-tensorboards-operator//charms/tensorboard-controller/terraform?ref=track/1.9"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.tensorboard_controller_revision
+  channel    = "1.9/${var.risk}"
 }
 
 module "tensorboards_web_app" {
   source     = "git::https://github.com/canonical/kubeflow-tensorboards-operator//charms/tensorboards-web-app/terraform?ref=track/1.9"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.tensorboards_web_app_revision
+  channel    = "1.9/${var.risk}"
 }
 
 module "training_operator" {
   source     = "git::https://github.com/canonical/training-operator//terraform?ref=track/1.8"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.training_operator_revision
+  channel    = "1.8/${var.risk}"
 }

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -23,7 +23,7 @@ module "dex_auth" {
     "static-password" : var.dex_static_password
   }
   revision = var.dex_auth_revision
-  channel    = "2.39/${var.risk}"
+  channel  = "2.39/${var.risk}"
 }
 
 module "envoy" {
@@ -41,7 +41,7 @@ module "istio_ingressgateway" {
     kind = "ingress",
   }
   revision = var.istio_ingressgateway_revision
-  channel    = "1.22/${var.risk}"
+  channel  = "1.22/${var.risk}"
 }
 
 module "istio_pilot" {
@@ -52,7 +52,7 @@ module "istio_pilot" {
     "tls-secret-id" : var.istio_tls_secret_id
   }
   revision = var.istio_pilot_revision
-  channel    = "1.22/${var.risk}"
+  channel  = "1.22/${var.risk}"
 }
 
 module "jupyter_controller" {
@@ -182,7 +182,7 @@ module "knative_eventing" {
     namespace = "knative-eventing"
   }
   revision = var.knative_eventing_revision
-  channel    = "1.12/${var.risk}"
+  channel  = "1.12/${var.risk}"
 }
 
 module "knative_operator" {
@@ -204,7 +204,7 @@ module "knative_serving" {
     no-proxy                  = var.no_proxy,
   }
   revision = var.knative_serving_revision
-  channel    = "1.12/${var.risk}"
+  channel  = "1.12/${var.risk}"
 }
 
 module "kserve_controller" {
@@ -217,7 +217,7 @@ module "kserve_controller" {
     no-proxy        = var.no_proxy,
   }
   revision = var.kserve_controller_revision
-  channel    = "0.13/${var.risk}"
+  channel  = "0.13/${var.risk}"
 }
 
 module "kubeflow_dashboard" {
@@ -262,7 +262,7 @@ module "mlmd" {
     mlmd-data = var.mlmd_size
   }
   revision = var.mlmd_revision
-  channel    = "ckf-1.9/${var.risk}"
+  channel  = "ckf-1.9/${var.risk}"
 }
 
 module "minio" {
@@ -272,7 +272,7 @@ module "minio" {
     minio-data = var.minio_size
   }
   revision = var.minio_revision
-  channel    = "ckf-1.9/${var.risk}"
+  channel  = "ckf-1.9/${var.risk}"
 }
 
 module "oidc_gatekeeper" {

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -6,7 +6,7 @@ variable "risk" {
   validation {
     condition     = contains(["stable", "candidate", "beta", "edge"], var.risk)
     error_message = "Valid values for var: risk are (stable, candidate, beta and edge)."
-  } 
+  }
 }
 
 variable "cos_configuration" {

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -1,3 +1,14 @@
+variable "risk" {
+  type        = string
+  description = "Value for the risk to be used"
+  default     = "stable"
+
+  validation {
+    condition     = contains(["stable", "candidate", "beta", "edge"], var.risk)
+    error_message = "Valid values for var: risk are (stable, candidate, beta and edge)."
+  } 
+}
+
 variable "cos_configuration" {
   description = "Boolean value that enables COS configuration"
   type        = bool


### PR DESCRIPTION
The PR proposes how to handle risk in the product bundle. The idea here is that:

1. In the bundle solution we don't want to support customizing tracks, as the track is decided by the solution itself (i.e. `kubeflow` 1.9 does not support ANY track for `kubeflow-pipeline`, but just the one we provide)
2. Allow customization of the risk (which gets propagated throughout channels in the bundle to make sure we are consistent, such that an edge deployment means all components on the edge track, same for beta, candidate and edge)
3. Allow still pinning of single revisions for charms, such that the product bundle can be used in deployments in a reproducible and consistent way

Initially I tried to have the high-level versions for all components (kfp, katib, etc) in a single file as locals variable, like

```
locals {
    track = {
        kfp = "2.3"
        katib = "0.17"
        ...
   }
}
```

To then use this in the channel and source, like:

```
module "katib_db_manager" {
  source     = "git::https://github.com/canonical/katib-operators//charms/katib-db-manager/terraform?ref=track/${locals.track.katib}"
  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
  revision   = var.katib_db_manager_revision
  channel    = "${locals.track.katib}/${var.risk}"
}
```

However, `source` must be [hardcoded in terraform](https://github.com/hashicorp/terraform/issues/1439), but [seems to be possible in opentofu](https://github.com/opentofu/opentofu/issues/1042). Given this, I don't think it is worth using the locals for two reasons:
1. Channel updates still requires to update the track in the source
2. Moving the definition away from the module may increase the risk of inconsistencies (updating locals but not the source). Having them very close to each other will allow to spot bugs and inconsistencies a lot more IMHO