### PR TITLE
feat: add deploy Kubeflow+Feast to AKS test and workflow

### DIFF
--- a/.github/workflows/deploy-to-aks-feast.yaml
+++ b/.github/workflows/deploy-to-aks-feast.yaml
@@ -88,7 +88,7 @@ jobs:
           cd ~/charmed-kubeflow-uats
           git checkout ${{ env.UATS_BRANCH }}
           # TODO: remove --bundle when feast is promoted to stable 
-          tox -e feast-remote --bundle https://raw.githubusercontent.com/canonical/bundle-kubeflow/refs/heads/main/releases/1.10/stable/bundle.yaml
+          tox -e feast-remote -- --bundle https://raw.githubusercontent.com/canonical/bundle-kubeflow/refs/heads/main/releases/1.10/stable/bundle.yaml
 
       # On failure, capture debugging resources
       - name: Select model

--- a/.github/workflows/deploy-to-aks-feast.yaml
+++ b/.github/workflows/deploy-to-aks-feast.yaml
@@ -1,0 +1,138 @@
+name: Create AKS cluster, deploy kubeflow-feast Terraform solution and run UATs
+on:
+  workflow_dispatch:
+    inputs:
+      k8s_version:
+        description: 'Kubernetes version to be used for the AKS cluster. Make sure that the corresponding K8s version is supported by the cloud.'
+        required: false
+      uats_branch:
+        description: 'Branch to run the UATs from e.g. main or track/1.10. By default, this is defined by the dependencies.yaml file.'
+        required: false
+  schedule:
+    - cron: "17 02 * * 1"
+
+jobs:
+  deploy-solution-to-aks:
+    name: Deploy CKF + Feast solution to AKS
+    runs-on: ubuntu-24.04
+    env:
+      AZURE_CORE_OUTPUT: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Run YAML to Github Output Action
+        id: yaml-output
+        uses: christian-ci/action-yaml-github-output@v2
+        with:
+          file_path: ".github/dependencies.yaml"
+
+      - name: Update ENV variables from inputs if available
+        run: |
+          K8S_VERSION=${{ inputs.k8s_version || env.K8S_VERSION }}
+          echo "K8S_VERSION=${K8S_VERSION}" >> $GITHUB_ENV
+          UATS_BRANCH=${{ inputs.uats_branch || env.UATS_BRANCH }}
+          echo "UATS_BRANCH=${UATS_BRANCH}" >> $GITHUB_ENV
+
+      - name: Install CLI tools
+        run: |
+          pip install tox
+          sudo snap install juju --channel=${{ env.JUJU_VERSION }}/stable
+          sudo snap install charmcraft --classic
+          sudo snap install terraform  --channel latest/stable --classic
+          juju version
+          terraform --version
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.CHARMED_KUBEFLOW_SOLUTIONS_AKS_SERVICE_PRINCIPAL }}
+
+      - name: Create resource group and cluster
+        run: |
+          # We need to remove the dot from version
+          # due to cluster naming restrictions
+          version=${{ env.CKF_VERSION }}
+          KF_VERSION="kf-${version//.}"
+          RESOURCE_GROUP=terraform-${KF_VERSION}-ResourceGroup
+          NAME=terraform-${KF_VERSION}-AKSCluster
+          LOCATION=westeurope
+          echo "RESOURCE_GROUP=${RESOURCE_GROUP}" >> $GITHUB_ENV
+          echo "NAME=${NAME}" >> $GITHUB_ENV
+          echo "LOCATION=${LOCATION}" >> $GITHUB_ENV
+          az group create --name ${RESOURCE_GROUP} --location ${LOCATION}
+          az aks create \
+            --resource-group ${RESOURCE_GROUP} \
+            --name ${NAME} \
+            --kubernetes-version ${{ env.K8S_VERSION }} \
+            --node-count 2 \
+            --node-vm-size Standard_D8s_v3 \
+            --node-osdisk-size 100 \
+            --node-osdisk-type Managed \
+            --os-sku Ubuntu \
+            --no-ssh-key
+
+      - name: Add AKS cloud to juju and bootstrap controller
+        run: |
+          az aks get-credentials --resource-group ${{ env.RESOURCE_GROUP }} --name ${{ env.NAME }} --admin
+          juju add-k8s aks --client
+          juju bootstrap aks aks-controller
+
+      - name: Deploy and assert kubeflow-feast solution
+        run: |
+          tox -c ./modules/kubeflow-feast -vve test_deployment -- -vv -s
+
+      - name: Run UATs
+        run: echo "WARNING UATs not yet implemented, skipping"
+
+      # On failure, capture debugging resources
+      - name: Select model
+        run: juju switch aks-controller:kubeflow
+        if: failure() || cancelled()
+
+      - name: Save debug artifacts
+        uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
+        if: failure() || cancelled()
+
+      - name: Get juju status
+        run: juju status
+        if: failure() || cancelled()
+
+      - name: Get juju debug logs
+        run: juju debug-log --replay --no-tail
+        if: failure() || cancelled()
+
+      - name: Get all kubernetes resources
+        run: kubectl get all -A
+        if: failure() || cancelled()
+
+      - name: Describe all pods
+        if: failure() || cancelled()
+        run: kubectl describe pods --all-namespaces
+
+      - name: Get logs from pods with status = Pending
+        run: kubectl -n kubeflow get pods | tail -n +2 | grep Pending | awk '{print $1}' | xargs -n1 kubectl -n kubeflow logs --all-containers=true --tail 100
+        if: failure() || cancelled()
+
+      - name: Get logs from pods with status = Failed
+        run: kubectl -n kubeflow get pods | tail -n +2 | grep Failed | awk '{print $1}' | xargs -n1 kubectl -n kubeflow logs --all-containers=true --tail 100
+        if: failure() || cancelled()
+
+      - name: Get logs from pods with status = CrashLoopBackOff
+        run: kubectl -n kubeflow get pods | tail -n +2 | grep CrashLoopBackOff | awk '{print $1}' | xargs -n1 kubectl -n kubeflow logs --all-containers=true --tail 100
+        if: failure() || cancelled()
+
+      - name: Delete resource groups
+        if: always() || cancelled()
+        run: |
+          az group delete --name ${{ env.RESOURCE_GROUP }} --yes
+          if [ "$(az group exists --name MC_${{ env.RESOURCE_GROUP }}_${{ env.NAME }}_${{ env.LOCATION }})" = "true" ]; then
+            az group delete --name MC_${{ env.RESOURCE_GROUP }}_${{ env.NAME }}_${{ env.LOCATION }} --yes
+          fi
+
+      - name: Check that resource groups have been deleted, else fail
+        if: always() || cancelled()
+        run: |
+          if [ "$(az group exists --name ${{ env.RESOURCE_GROUP }} )" = "true" ] || [ "$(az group exists --name MC_${{ env.RESOURCE_GROUP }}_${{ env.NAME }}_${{ env.LOCATION }})" = "true" ]; then
+            exit 1
+          fi

--- a/.github/workflows/deploy-to-aks-feast.yaml
+++ b/.github/workflows/deploy-to-aks-feast.yaml
@@ -83,7 +83,12 @@ jobs:
           tox -c ./modules/kubeflow-feast -vve test_deployment -- -vv -s
 
       - name: Run UATs
-        run: echo "WARNING UATs not yet implemented, skipping"
+        run: |
+          git clone https://github.com/canonical/charmed-kubeflow-uats.git ~/charmed-kubeflow-uats
+          cd ~/charmed-kubeflow-uats
+          git checkout ${{ env.UATS_BRANCH }}
+          # TODO: remove --bundle when feast is promoted to stable 
+          tox -e feast-remote --bundle https://raw.githubusercontent.com/canonical/bundle-kubeflow/refs/heads/main/releases/1.10/stable/bundle.yaml
 
       # On failure, capture debugging resources
       - name: Select model

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -87,7 +87,7 @@ jobs:
           git clone https://github.com/canonical/charmed-kubeflow-uats.git ~/charmed-kubeflow-uats
           cd ~/charmed-kubeflow-uats
           git checkout ${{ env.UATS_BRANCH }}
-          tox -e uats-remote
+          tox -e uats-remote -- --filter "not feast"
 
       # On failure, capture debugging resources
       - name: Select model

--- a/modules/kubeflow-feast/tests/conftest.py
+++ b/modules/kubeflow-feast/tests/conftest.py
@@ -3,43 +3,21 @@
 import jubilant
 import pytest
 
+MODEL_NAME = "kubeflow"
 
 @pytest.fixture(scope="module")
 def juju(request: pytest.FixtureRequest):
-    keep_models = bool(request.config.getoption("--keep-models"))
-    model_name = request.config.getoption("--model")
-
+    
     def print_debug_log(juju_instance: jubilant.Juju):
         if request.session.testsfailed:
             print(f"[DEBUG] Fetching debug log for model: {juju_instance.model}")
             log = juju_instance.debug_log(limit=1000)
             print(log, end="")
 
-    if model_name:
-        juju_instance = jubilant.Juju(model=model_name)
-        try:
-            yield juju_instance
-        finally:
-            print_debug_log(juju_instance)
-    else:
-        with jubilant.temp_model(keep=keep_models) as juju_instance:
-            try:
-                yield juju_instance
-            finally:
-                print_debug_log(juju_instance)
+    juju_instance = jubilant.Juju()
+    juju_instance.add_model(MODEL_NAME)
 
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--keep-models",
-        action="store_true",
-        default=False,
-        help="keep temporarily-created models",
-    )
-    parser.addoption(
-        "--model",
-        action="store",
-        help="Juju model to use; if not provided, a new model "
-        "will be created for each test which requires one",
-        default=None,
-    )
+    try:
+        yield juju_instance
+    finally:
+        print_debug_log(juju_instance)

--- a/modules/kubeflow-feast/tests/conftest.py
+++ b/modules/kubeflow-feast/tests/conftest.py
@@ -1,0 +1,45 @@
+# tests/integration/conftest.py
+
+import jubilant
+import pytest
+
+
+@pytest.fixture(scope="module")
+def juju(request: pytest.FixtureRequest):
+    keep_models = bool(request.config.getoption("--keep-models"))
+    model_name = request.config.getoption("--model")
+
+    def print_debug_log(juju_instance: jubilant.Juju):
+        if request.session.testsfailed:
+            print(f"[DEBUG] Fetching debug log for model: {juju_instance.model}")
+            log = juju_instance.debug_log(limit=1000)
+            print(log, end="")
+
+    if model_name:
+        juju_instance = jubilant.Juju(model=model_name)
+        try:
+            yield juju_instance
+        finally:
+            print_debug_log(juju_instance)
+    else:
+        with jubilant.temp_model(keep=keep_models) as juju_instance:
+            try:
+                yield juju_instance
+            finally:
+                print_debug_log(juju_instance)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--keep-models",
+        action="store_true",
+        default=False,
+        help="keep temporarily-created models",
+    )
+    parser.addoption(
+        "--model",
+        action="store",
+        help="Juju model to use; if not provided, a new model "
+        "will be created for each test which requires one",
+        default=None,
+    )

--- a/modules/kubeflow-feast/tests/test_deployment.py
+++ b/modules/kubeflow-feast/tests/test_deployment.py
@@ -15,7 +15,7 @@ def lightkube_client() -> lightkube.Client:
 
 class TestCharm:
     @pytest.mark.dependency()
-    async def test_apply_terraform_solution(self):
+    async def test_apply_terraform_solution(self, juju: jubilant.Juju):
         """Initialize and apply the kubeflow-feast Terraform solution module."""
         subprocess.run(["terraform", "init"], check=True)
         subprocess.run(

--- a/modules/kubeflow-feast/tests/test_deployment.py
+++ b/modules/kubeflow-feast/tests/test_deployment.py
@@ -24,6 +24,8 @@ class TestCharm:
                 "apply",
                 "-var",
                 "cos_configuration=true",
+                "-var",
+                "create_model=false",
                 "-auto-approve",
             ],
             check=True,

--- a/modules/kubeflow-feast/tests/test_deployment.py
+++ b/modules/kubeflow-feast/tests/test_deployment.py
@@ -1,0 +1,76 @@
+import subprocess
+
+import aiohttp
+import jubilant
+import lightkube
+import pytest
+from lightkube.resources.core_v1 import Service
+
+
+@pytest.fixture()
+def lightkube_client() -> lightkube.Client:
+    client = lightkube.Client(field_manager="kubeflow")
+    return client
+
+
+class TestCharm:
+    @pytest.mark.dependency()
+    async def test_apply_terraform_solution(self):
+        """Initialize and apply the kubeflow-feast Terraform solution module."""
+        subprocess.run(["terraform", "init"], check=True)
+        subprocess.run(
+            [
+                "terraform",
+                "apply",
+                "-var",
+                "cos_configuration=true",
+                "-auto-approve",
+            ],
+            check=True,
+        )
+
+    @pytest.mark.dependency(depends=["TestCharm::test_apply_terraform_solution"])
+    async def test_assert_deployment(self, juju: jubilant.Juju, lightkube_client):
+        """
+        Wait for the applications to become active and idle and verify its public URL access.
+        """
+
+        apps = list(juju.status().apps.keys())
+
+        # Remove grafana-agent-k8s from the apps list because it remains
+        # `blocked` until it's related to one of the COS charms
+        apps.remove("grafana-agent-k8s-kubeflow")
+
+        juju.wait(lambda status: jubilant.all_active(status, *apps), timeout=3600)
+
+        # Verify deployment by checking the public URL
+        url = get_public_url(lightkube_client, "kubeflow")
+        result_status, result_text = await fetch_response(url)
+        assert result_status == 200
+        assert "Log in to Your Account" in result_text
+        assert "Email Address" in result_text
+        assert "Password" in result_text
+
+
+def get_public_url(lightkube_client: lightkube.Client, bundle_name: str):
+    """Extracts public URL from service istio-ingressgateway-workload."""
+    ingressgateway_svc = lightkube_client.get(
+        Service, "istio-ingressgateway-workload", namespace=bundle_name
+    )
+    address = (
+        ingressgateway_svc.status.loadBalancer.ingress[0].hostname
+        or ingressgateway_svc.status.loadBalancer.ingress[0].ip
+    )
+    public_url = f"http://{address}"
+    return public_url
+
+
+async def fetch_response(url, headers=None):
+    """Fetch provided URL and return (status, text)."""
+    result_status = 0
+    result_text = ""
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url=url, headers=headers) as response:
+            result_status = response.status
+            result_text = await response.text()
+    return result_status, str(result_text)

--- a/modules/kubeflow-feast/tox.ini
+++ b/modules/kubeflow-feast/tox.ini
@@ -2,7 +2,19 @@
 # See LICENSE file for licensing details.
 
 [tox]
-envlist = tflint
+skipsdist = True
+envlist = tflint, test_deployment
+
+[vars]
+tst_path = {toxinidir}/tests
+
+[testenv]
+passenv =
+    KUBECONFIG
+    PYTHONPATH
+setenv =
+    # Needed for juju cli to work correctly
+    HOME={env:HOME}
 
 [testenv:tflint]
 description = Check Terraform code against coding style standards
@@ -10,3 +22,15 @@ allowlist_externals =
     tflint
 commands =
     tflint --recursive
+
+[testenv:test_deployment]
+commands =
+    pytest -v --tb native --asyncio-mode=auto tests/test_deployment.py --model kubeflow --log-cli-level=INFO -s {posargs}
+deps =
+    aiohttp
+    lightkube
+    tenacity
+    jubilant
+    juju<4.0.0
+    pytest-dependency
+description = Test bundle deployment

--- a/modules/kubeflow-feast/tox.ini
+++ b/modules/kubeflow-feast/tox.ini
@@ -25,7 +25,7 @@ commands =
 
 [testenv:test_deployment]
 commands =
-    pytest -v --tb native --asyncio-mode=auto tests/test_deployment.py --model kubeflow --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --asyncio-mode=auto tests/test_deployment.py --log-cli-level=INFO -s {posargs}
 deps =
     aiohttp
     lightkube
@@ -33,4 +33,5 @@ deps =
     jubilant
     juju<4.0.0
     pytest-dependency
+    pytest-asyncio
 description = Test bundle deployment

--- a/modules/kubeflow-mlflow/tests/test_deployment.py
+++ b/modules/kubeflow-mlflow/tests/test_deployment.py
@@ -3,6 +3,7 @@ import subprocess
 import aiohttp
 import lightkube
 import pytest
+import tenacity
 from lightkube.resources.core_v1 import Service
 from pytest_operator.plugin import OpsTest
 
@@ -61,6 +62,11 @@ class TestCharm:
         assert "Password" in result_text
 
 
+@tenacity.retry(
+    wait=tenacity.wait_exponential(multiplier=2, min=1, max=10),
+    stop=tenacity.stop_after_attempt(30),
+    reraise=True,
+)
 def get_public_url(lightkube_client: lightkube.Client, bundle_name: str):
     """Extracts public URL from service istio-ingressgateway-workload."""
     ingressgateway_svc = lightkube_client.get(


### PR DESCRIPTION
Part of https://github.com/canonical/charmed-kubeflow-uats/issues/180

## Testing
See [this run](https://github.com/canonical/charmed-kubeflow-solutions/actions/runs/15609042213/job/43965294798).
I have tested running the workflow in the CI by overriding the `deploy-to-aks.yaml` workflow in a draft branch from #38 since this is a new workflow I needed a way to override an existing workflow to be able to run it from the actions. #38 will be closed once this PR is merged. 
Note the run is running the UATs from the branch of https://github.com/canonical/charmed-kubeflow-uats/pull/189.