### PR TITLE
fix: add prefix to AKS resources names to avoid conflict

### DIFF
--- a/.github/workflows/deploy-to-aks-feast.yaml
+++ b/.github/workflows/deploy-to-aks-feast.yaml
@@ -54,8 +54,8 @@ jobs:
           # due to cluster naming restrictions
           version=${{ env.CKF_VERSION }}
           KF_VERSION="kf-${version//.}"
-          RESOURCE_GROUP=terraform-${KF_VERSION}-ResourceGroup
-          NAME=terraform-${KF_VERSION}-AKSCluster
+          RESOURCE_GROUP=feast-terraform-${KF_VERSION}-ResourceGroup
+          NAME=feast-terraform-${KF_VERSION}-AKSCluster
           LOCATION=westeurope
           echo "RESOURCE_GROUP=${RESOURCE_GROUP}" >> $GITHUB_ENV
           echo "NAME=${NAME}" >> $GITHUB_ENV

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -54,8 +54,8 @@ jobs:
           # due to cluster naming restrictions
           version=${{ env.CKF_VERSION }}
           KF_VERSION="kf-${version//.}"
-          RESOURCE_GROUP=terraform-${KF_VERSION}-ResourceGroup
-          NAME=terraform-${KF_VERSION}-AKSCluster
+          RESOURCE_GROUP=ckf-terraform-${KF_VERSION}-ResourceGroup
+          NAME=ckf-terraform-${KF_VERSION}-AKSCluster
           LOCATION=westeurope
           echo "RESOURCE_GROUP=${RESOURCE_GROUP}" >> $GITHUB_ENV
           echo "NAME=${NAME}" >> $GITHUB_ENV


### PR DESCRIPTION
adds a prefix to each of the resource group and cluster names to avoid conflict when both workflows run at the same time