### PR TITLE
tests: Replace github action with bash script

### DIFF
--- a/.github/workflows/deploy-to-aks-feast.yaml
+++ b/.github/workflows/deploy-to-aks-feast.yaml
@@ -22,11 +22,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Run YAML to Github Output Action
-        id: yaml-output
-        uses: christian-ci/action-yaml-github-output@v2
-        with:
-          file_path: ".github/dependencies.yaml"
+      - name: Set envvars from dependencies.yaml
+        run: |
+          yq eval 'to_entries | .[] | "\(.key)=\(.value)"' ".github/dependencies.yaml" | while IFS= read -r line; do
+            echo "$line" >> "$GITHUB_ENV"
+          done
 
       - name: Update ENV variables from inputs if available
         run: |

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -22,11 +22,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Run YAML to Github Output Action
-        id: yaml-output
-        uses: christian-ci/action-yaml-github-output@v2
-        with:
-          file_path: ".github/dependencies.yaml"
+      - name: Set envvars from dependencies.yaml
+        run: |
+          yq eval 'to_entries | .[] | "\(.key)=\(.value)"' ".github/dependencies.yaml" | while IFS= read -r line; do
+            echo "$line" >> "$GITHUB_ENV"
+          done
 
       - name: Update ENV variables from inputs if available
         run: |


### PR DESCRIPTION
Replace github action with small bash script. This is to enhance security since those workflows have access to credentials/repo's secrets. By default, the secrets are not accessible when there is no `secrets: inherit` argument passed. However, there were cases in the past where malicious code was able to access sensitive information, even without it e.g. tj-actions/changed-files#2463

This follows the same rationale from https://github.com/canonical/bundle-kubeflow/pull/1275. 

Example runs for:
* feast https://github.com/canonical/charmed-kubeflow-solutions/actions/runs/15704329407
* ckf-mlflow https://github.com/canonical/charmed-kubeflow-solutions/actions/runs/15704323687