### PR TITLE
fix: replace terraform with tf in resource names

### DIFF
--- a/.github/workflows/deploy-to-aks-feast.yaml
+++ b/.github/workflows/deploy-to-aks-feast.yaml
@@ -54,8 +54,8 @@ jobs:
           # due to cluster naming restrictions
           version=${{ env.CKF_VERSION }}
           KF_VERSION="kf-${version//.}"
-          RESOURCE_GROUP=feast-terraform-${KF_VERSION}-ResourceGroup
-          NAME=feast-terraform-${KF_VERSION}-AKSCluster
+          RESOURCE_GROUP=feast-tf-${KF_VERSION}-ResourceGroup
+          NAME=feast-tf-${KF_VERSION}-AKSCluster
           LOCATION=westeurope
           echo "RESOURCE_GROUP=${RESOURCE_GROUP}" >> $GITHUB_ENV
           echo "NAME=${NAME}" >> $GITHUB_ENV

--- a/.github/workflows/deploy-to-aks.yaml
+++ b/.github/workflows/deploy-to-aks.yaml
@@ -54,8 +54,8 @@ jobs:
           # due to cluster naming restrictions
           version=${{ env.CKF_VERSION }}
           KF_VERSION="kf-${version//.}"
-          RESOURCE_GROUP=ckf-terraform-${KF_VERSION}-ResourceGroup
-          NAME=ckf-terraform-${KF_VERSION}-AKSCluster
+          RESOURCE_GROUP=ckf-tf-${KF_VERSION}-ResourceGroup
+          NAME=ckf-tf-${KF_VERSION}-AKSCluster
           LOCATION=westeurope
           echo "RESOURCE_GROUP=${RESOURCE_GROUP}" >> $GITHUB_ENV
           echo "NAME=${NAME}" >> $GITHUB_ENV


### PR DESCRIPTION
Renames the resource names to be shorter due to character limit. We've seen the following error:
```
The length of the node resource group name is too long. The maximum length is 80 and the length of the value provided is 84. 
```
Example [run](https://github.com/canonical/charmed-kubeflow-solutions/actions/runs/15700912784/job/44235260637#step:8:31) where it failed.

## Testing
* [Run](https://github.com/canonical/charmed-kubeflow-solutions/actions/runs/15702576397) for kubeflow-feast
* [Run](https://github.com/canonical/charmed-kubeflow-solutions/actions/runs/15702588324) for kubeflow-mlflow