### PR TITLE
chore: update feast module source to `track/0.49` and remove `--bundle` arg

### DIFF
--- a/.github/workflows/deploy-to-aks-feast.yaml
+++ b/.github/workflows/deploy-to-aks-feast.yaml
@@ -87,8 +87,7 @@ jobs:
           git clone https://github.com/canonical/charmed-kubeflow-uats.git ~/charmed-kubeflow-uats
           cd ~/charmed-kubeflow-uats
           git checkout ${{ env.UATS_BRANCH }}
-          # TODO: remove --bundle when feast is promoted to stable 
-          tox -e feast-remote -- --bundle https://raw.githubusercontent.com/canonical/bundle-kubeflow/refs/heads/main/releases/1.10/stable/bundle.yaml
+          tox -e feast-remote
 
       # On failure, capture debugging resources
       - name: Select model

--- a/modules/kubeflow-feast/applications.tf
+++ b/modules/kubeflow-feast/applications.tf
@@ -1,13 +1,13 @@
 module "feast_integrator" {
   # tflint-ignore: terraform_module_pinned_source
-  source     = "git::https://github.com/canonical/feast-operators//charms/feast-integrator/terraform?ref=main"
+  source     = "git::https://github.com/canonical/feast-operators//charms/feast-integrator/terraform?ref=track/0.49"
   model_name = module.kubeflow.model
   revision   = var.feast_integrator_revision
 }
 
 module "feast_ui" {
   # tflint-ignore: terraform_module_pinned_source
-  source     = "git::https://github.com/canonical/feast-operators//charms/feast-ui/terraform?ref=main"
+  source     = "git::https://github.com/canonical/feast-operators//charms/feast-ui/terraform?ref=track/0.49"
   model_name = module.kubeflow.model
   revision   = var.feast_ui_revision
 }


### PR DESCRIPTION
Closes https://github.com/canonical/charmed-kubeflow-solutions/issues/39
Ref https://github.com/canonical/feast-operators/issues/19

Tested in [this run](https://github.com/canonical/charmed-kubeflow-solutions/actions/runs/15755652786) by running the UATs from the branch of https://github.com/canonical/charmed-kubeflow-uats/pull/193