### PR TITLE
chore: pin jupyter-ui revision and base containing feast notebook image

### DIFF
--- a/modules/kubeflow-feast/main.tf
+++ b/modules/kubeflow-feast/main.tf
@@ -24,7 +24,8 @@ module "kubeflow" {
   istio_ingressgateway_revision    = var.istio_ingressgateway_revision
   istio_pilot_revision             = var.istio_pilot_revision
   jupyter_controller_revision      = var.jupyter_controller_revision
-  jupyter_ui_revision              = var.jupyter_ui_revision
+  jupyter_ui_base                  = "ubuntu@24.04"  # Set base to 24.04 due to https://github.com/canonical/charmed-kubeflow-solutions/issues/47
+  jupyter_ui_revision              = 1209  # Pin revision due to https://github.com/canonical/charmed-kubeflow-solutions/issues/47
   katib_controller_revision        = var.katib_controller_revision
   katib_db_revision                = var.katib_db_revision
   katib_db_manager_revision        = var.katib_db_manager_revision

--- a/modules/kubeflow-feast/main.tf
+++ b/modules/kubeflow-feast/main.tf
@@ -24,7 +24,7 @@ module "kubeflow" {
   istio_ingressgateway_revision    = var.istio_ingressgateway_revision
   istio_pilot_revision             = var.istio_pilot_revision
   jupyter_controller_revision      = var.jupyter_controller_revision
-  jupyter_ui_revision              = var.jupyter_ui_revision
+  jupyter_ui_revision              = 1209
   katib_controller_revision        = var.katib_controller_revision
   katib_db_revision                = var.katib_db_revision
   katib_db_manager_revision        = var.katib_db_manager_revision

--- a/modules/kubeflow-feast/main.tf
+++ b/modules/kubeflow-feast/main.tf
@@ -24,7 +24,7 @@ module "kubeflow" {
   istio_ingressgateway_revision    = var.istio_ingressgateway_revision
   istio_pilot_revision             = var.istio_pilot_revision
   jupyter_controller_revision      = var.jupyter_controller_revision
-  jupyter_ui_revision              = 1209
+  jupyter_ui_revision              = var.jupyter_ui_revision
   katib_controller_revision        = var.katib_controller_revision
   katib_db_revision                = var.katib_db_revision
   katib_db_manager_revision        = var.katib_db_manager_revision

--- a/modules/kubeflow-feast/main.tf
+++ b/modules/kubeflow-feast/main.tf
@@ -24,8 +24,8 @@ module "kubeflow" {
   istio_ingressgateway_revision    = var.istio_ingressgateway_revision
   istio_pilot_revision             = var.istio_pilot_revision
   jupyter_controller_revision      = var.jupyter_controller_revision
-  jupyter_ui_base                  = "ubuntu@24.04"  # Set base to 24.04 due to https://github.com/canonical/charmed-kubeflow-solutions/issues/47
-  jupyter_ui_revision              = 1209  # Pin revision due to https://github.com/canonical/charmed-kubeflow-solutions/issues/47
+  jupyter_ui_base                  = "ubuntu@24.04" # Set base to 24.04 due to https://github.com/canonical/charmed-kubeflow-solutions/issues/47
+  jupyter_ui_revision              = 1209           # Pin revision due to https://github.com/canonical/charmed-kubeflow-solutions/issues/47
   katib_controller_revision        = var.katib_controller_revision
   katib_db_revision                = var.katib_db_revision
   katib_db_manager_revision        = var.katib_db_manager_revision

--- a/modules/kubeflow-feast/variables.tf
+++ b/modules/kubeflow-feast/variables.tf
@@ -162,11 +162,14 @@ variable "jupyter_controller_revision" {
   default     = null
 }
 
-variable "jupyter_ui_revision" {
-  description = "Charm revision for jupyter-ui"
-  type        = number
-  default     = 1209
-}
+# Comment out revision variable due to https://github.com/canonical/charmed-kubeflow-solutions/issues/47
+# Revision is currently pinned in main.tf
+# Uncomment when jupyter-ui 1.10/edge is promoted to 1.10/stable
+# variable "jupyter_ui_revision" {
+#   description = "Charm revision for jupyter-ui"
+#   type        = number
+#   default     = null
+# }
 
 variable "katib_controller_revision" {
   description = "Charm revision for katib-controller"

--- a/modules/kubeflow-feast/variables.tf
+++ b/modules/kubeflow-feast/variables.tf
@@ -165,7 +165,7 @@ variable "jupyter_controller_revision" {
 variable "jupyter_ui_revision" {
   description = "Charm revision for jupyter-ui"
   type        = number
-  default     = null
+  default     = 1209
 }
 
 variable "katib_controller_revision" {

--- a/modules/kubeflow/README.md
+++ b/modules/kubeflow/README.md
@@ -21,6 +21,7 @@ The solution module offers the following configurable inputs:
 | `http_proxy`| string | Value of the http_proxy environment variable | False |
 | `https_proxy`| string | Value of the https_proxy environment variable | False |
 | `istio_tls_secret_id`| string | The juju secret id for the tls key/cert for istio-pilot | False |
+| `jupyter_ui_base` | string | Charm base for jupyter-ui | False |
 | `jupyter_ui_config`| map(string) | Map of config values passed to jupyter-ui | False |
 | `katib_db_size`| string | Katib database storage size | False |
 | `kfp_db_size`| string | KFP database storage size | False |

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -68,6 +68,7 @@ module "jupyter_ui" {
   config     = var.jupyter_ui_config
   revision   = var.jupyter_ui_revision
   channel    = "1.10/stable"
+  base       = var.jupyter_ui_base
 }
 
 module "katib_controller" {

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -150,6 +150,12 @@ variable "jupyter_controller_revision" {
   default     = null
 }
 
+variable "jupyter_ui_base" {
+  description = "Charm base for jupyter-ui"
+  type        = string
+  default     = null
+}
+
 variable "jupyter_ui_revision" {
   description = "Charm revision for jupyter-ui"
   type        = number


### PR DESCRIPTION
* Adds a `jupyter_ui_base` variable to `kubeflow` solution and uses it in `jupyter_ui` module to set the `base`
* Updates the `kubeflow-feast` solution to set the `jupyter_ui_base` to `24.04` to be able to pull the recent revision containing the feast notebook image
* Pins the value of `jupyter_ui_revision` in `kubeflow-feast` solution to `1209`
* Removes the `jupyter_ui_revision` variable from `kubeflow-feast` solution with a comment

See #47 for details on why we are doing the pinning