### PR TITLE
fix: update default channel for grafana-agent-k8s (#48)

### DIFF
--- a/modules/kubeflow/cos_configuration.tf
+++ b/modules/kubeflow/cos_configuration.tf
@@ -4,7 +4,7 @@ resource "juju_application" "grafana_agent_k8s" {
   count = var.cos_configuration && var.existing_grafana_agent_name == null ? 1 : 0
   charm {
     name     = "grafana-agent-k8s"
-    channel  = "latest/stable"
+    channel  = "1/stable"
     revision = var.grafana_agent_k8s_revision
   }
   model = var.create_model ? juju_model.kubeflow[0].name : local.model


### PR DESCRIPTION
Backports #48
Ref https://github.com/canonical/charmed-kubeflow-chisme/issues/155

Updates the channel of grafana-agent-k8s charm to 1/stable due to the latest channel being deprecated [as announced](https://discourse.charmhub.io/t/closing-the-latest-track-for-all-observability-charms/18054).