### PR TITLE
feat: add various config options to minio, kfp-api and argo-controller

### DIFF
--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -13,8 +13,14 @@ module "kubeflow" {
   istio_tls_secret_id              = var.istio_tls_secret_id
   jupyter_ui_config                = var.jupyter_ui_config
   katib_db_size                    = var.katib_db_size
+  kfp_api_object_store_bucket_name = var.kfp_api_object_store_bucket_name
   kfp_db_size                      = var.kfp_db_size
+  minio_access_key                 = var.minio_access_key
+  minio_gateway_storage_service    = var.minio_gateway_storage_service
+  minio_mode                       = var.minio_mode
+  minio_secret_key                 = var.minio_secret_key
   minio_size                       = var.minio_size
+  minio_storage_service_endpoint   = var.minio_storage_service_endpoint
   mlmd_size                        = var.mlmd_size
   no_proxy                         = var.no_proxy
   public_url                       = var.public_url
@@ -61,18 +67,24 @@ module "kubeflow" {
 module "mlflow" {
   source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=track/2.22"
   # kubeflow module creates the model
-  risk                        = var.risk
-  create_model                = false
-  model                       = module.kubeflow.model
-  cos_configuration           = var.cos_configuration
-  enable_mlflow_nodeport      = var.enable_mlflow_nodeport
-  existing_grafana_agent_name = var.cos_configuration ? module.kubeflow.grafana_agent_k8s.app_name : null
-  mlflow_minio_revision       = var.mlflow_minio_revision
-  mlflow_minio_size           = var.mlflow_minio_size
-  mlflow_mysql_revision       = var.mlflow_mysql_revision
-  mlflow_mysql_size           = var.mlflow_mysql_size
-  mlflow_nodeport             = var.mlflow_nodeport
-  mlflow_server_revision      = var.mlflow_server_revision
+  risk                                  = var.risk
+  create_model                          = false
+  model                                 = module.kubeflow.model
+  cos_configuration                     = var.cos_configuration
+  enable_mlflow_nodeport                = var.enable_mlflow_nodeport
+  existing_grafana_agent_name           = var.cos_configuration ? module.kubeflow.grafana_agent_k8s.app_name : null
+  mlflow_default_artifact_root          = var.mlflow_default_artifact_root
+  mlflow_minio_revision                 = var.mlflow_minio_revision
+  mlflow_minio_access_key               = var.mlflow_minio_access_key
+  mlflow_minio_gateway_storage_service  = var.mlflow_minio_gateway_storage_service
+  mlflow_minio_mode                     = var.mlflow_minio_mode
+  mlflow_minio_secret_key               = var.mlflow_minio_secret_key
+  mlflow_minio_size                     = var.mlflow_minio_size
+  mlflow_minio_storage_service_endpoint = var.mlflow_minio_storage_service_endpoint
+  mlflow_mysql_revision                 = var.mlflow_mysql_revision
+  mlflow_mysql_size                     = var.mlflow_mysql_size
+  mlflow_nodeport                       = var.mlflow_nodeport
+  mlflow_server_revision                = var.mlflow_server_revision
 }
 
 module "resource_dispatcher" {

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -1,6 +1,7 @@
 module "kubeflow" {
   source                           = "../kubeflow"
   risk                             = var.risk
+  argo_controller_bucket           = var.argo_controller_bucket
   create_model                     = var.create_model
   cos_configuration                = var.cos_configuration
   dex_connectors                   = var.dex_connectors

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -89,16 +89,53 @@ variable "katib_db_size" {
   default     = "10G"
 }
 
+variable "kfp_api_object_store_bucket_name" {
+  description = "The name of the bucket to be used by KFP API in the object store"
+  type        = string
+  default     = "mlpipeline"
+}
+
 variable "kfp_db_size" {
   description = "KFP database storage size"
   type        = string
   default     = "10G"
 }
 
+variable "minio_access_key" {
+  description = "MinIO access key"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "minio_gateway_storage_service" {
+  description = "Gateway storage service configuration for MinIO when in 'gateway' mode"
+  type        = any
+  default     = {}
+}
+
+variable "minio_mode" {
+  description = "MinIO mode, either 'server' or 'gateway'"
+  type        = string
+  default     = "server"
+}
+
 variable "minio_size" {
   description = "MinIO database storage size"
   type        = string
   default     = "10G"
+}
+variable "minio_secret_key" {
+  description = "MinIO secret key"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "minio_storage_service_endpoint" {
+  description = "MinIO storage service endpoint, required if minio_mode is 'gateway'"
+  type        = string
+  default     = ""
 }
 
 variable "mlflow_dashboard_link" {
@@ -107,16 +144,54 @@ variable "mlflow_dashboard_link" {
   default     = true
 }
 
+variable "mlflow_default_artifact_root" {
+  description = "The default bucket MLflow uses for artifacts"
+  type        = string
+  default     = "mlflow"
+}
+
 variable "mlflow_kserve_integration" {
   description = "Boolean value that enables MLFlow-KServe configuration"
   type        = bool
   default     = true
 }
 
+variable "mlflow_minio_access_key" {
+  description = "MinIO access key for MLflow"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "mlflow_minio_gateway_storage_service" {
+  description = "Gateway storage service configuration for MinIO when in 'gateway' mode for MLflow"
+  type        = string
+  default     = ""
+}
+
+variable "mlflow_minio_mode" {
+  description = "MinIO mode for MLflow, either 'server' or 'gateway'"
+  type        = string
+  default     = "server"
+}
+
+variable "mlflow_minio_secret_key" {
+  description = "MinIO secret key for MLflow"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "mlflow_minio_size" {
   description = "MinIO database storage size"
   type        = string
   default     = "10G"
+}
+
+variable "mlflow_minio_storage_service_endpoint" {
+  description = "MinIO storage service endpoint for MLflow, required if minio_mode is 'gateway'"
+  type        = string
+  default     = ""
 }
 
 variable "mlflow_mysql_size" {

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -9,6 +9,12 @@ variable "risk" {
   }
 }
 
+variable "argo_controller_bucket" {
+  description = "The name of the bucket to be used by Argo controller in the object store"
+  type        = string
+  default     = "mlpipeline"
+}
+
 variable "create_model" {
   description = "Allows to skip Juju model creation and re-use a model created in a higher level module. When re-using a model, if this is created by Terraform, make sure that the current module depends on the resource using the depends_on option."
   type        = bool

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -116,8 +116,8 @@ variable "minio_access_key" {
 
 variable "minio_gateway_storage_service" {
   description = "Gateway storage service configuration for MinIO when in 'gateway' mode"
-  type        = any
-  default     = {}
+  type        = string
+  default     = ""
 }
 
 variable "minio_mode" {

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -11,6 +11,9 @@ module "argo_controller" {
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.argo_controller_revision
   channel    = "3.5/${var.risk}"
+  config = {
+    bucket = var.argo_controller_bucket
+  }
 }
 
 module "dex_auth" {

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -109,7 +109,10 @@ module "kfp_api" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-api/terraform?ref=track/2.5"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_api_revision
-  channel    = "2.5/${var.risk}"
+  config = {
+    object-store-bucket-name = var.kfp_api_object_store_bucket_name
+  }
+  channel = "2.5/${var.risk}"
 }
 
 module "kfp_db" {
@@ -268,6 +271,13 @@ module "mlmd" {
 module "minio" {
   source     = "git::https://github.com/canonical/minio-operator//terraform?ref=track/ckf-1.10"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  config = {
+    access-key               = var.mlflow_minio_access_key,
+    secret-key               = var.mlflow_minio_secret_key,
+    mode                     = var.mlflow_minio_mode,
+    gateway-storage-service  = var.mlflow_minio_gateway_storage_service,
+    storage-service-endpoint = var.mlflow_minio_storage_service_endpoint,
+  }
   storage_directives = {
     minio-data = var.minio_size
   }

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -275,11 +275,11 @@ module "minio" {
   source     = "git::https://github.com/canonical/minio-operator//terraform?ref=track/ckf-1.10"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   config = {
-    access-key               = var.mlflow_minio_access_key,
-    secret-key               = var.mlflow_minio_secret_key,
-    mode                     = var.mlflow_minio_mode,
-    gateway-storage-service  = var.mlflow_minio_gateway_storage_service,
-    storage-service-endpoint = var.mlflow_minio_storage_service_endpoint,
+    access-key               = var.minio_access_key,
+    secret-key               = var.minio_secret_key,
+    mode                     = var.minio_mode,
+    gateway-storage-service  = var.minio_gateway_storage_service,
+    storage-service-endpoint = var.minio_storage_service_endpoint,
   }
   storage_directives = {
     minio-data = var.minio_size

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -83,16 +83,54 @@ variable "katib_db_size" {
   default     = "10G"
 }
 
+variable "kfp_api_object_store_bucket_name" {
+  description = "The name of the bucket to be used by KFP API in the object store"
+  type        = string
+  default     = "mlpipeline"
+}
+
 variable "kfp_db_size" {
   description = "KFP database storage size"
   type        = string
   default     = "10G"
 }
 
+variable "minio_access_key" {
+  description = "MinIO access key"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "minio_gateway_storage_service" {
+  description = "Gateway storage service configuration for MinIO when in 'gateway' mode"
+  type        = string
+  default     = ""
+}
+
+variable "minio_mode" {
+  description = "MinIO mode, either 'server' or 'gateway'"
+  type        = string
+  default     = "server"
+}
+
+variable "minio_secret_key" {
+  description = "MinIO secret key"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "minio_size" {
   description = "MinIO database storage size"
   type        = string
   default     = "10G"
+}
+
+variable "minio_storage_service_endpoint" {
+  description = "MinIO storage service endpoint, required if minio_mode is 'gateway'"
+  type        = string
+  default     = ""
 }
 
 variable "mlmd_size" {

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -9,6 +9,12 @@ variable "risk" {
   }
 }
 
+variable "argo_controller_bucket" {
+  description = "The name of the bucket to be used by Argo controller in the object store"
+  type        = string
+  default     = "mlpipeline"
+}
+
 variable "cos_configuration" {
   description = "Boolean value that enables COS configuration"
   type        = bool


### PR DESCRIPTION
Hi team,

This PR serves purpose of adding required charm config options mainly to be able to deploy MinIO in gateway mode.
The full list of added config options are:

- Argo Controller:
  -  bucket name
- MinIO 
  - access key
  - secret key
  - mode (server, gateway)
  - gateway storage service (if gateway)
  - storage service endpoint
- KFP API
  - object store bucket name

**Note:** This PR relies on https://github.com/canonical/charmed-mlflow-solutions/pull/16 as KF uses MLFlow as a module

