### PR TITLE
feat: add oidc_gatekeeper_ca_bundle config for custom CA setup

### DIFF
--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -58,6 +58,7 @@ module "kubeflow" {
   mlmd_revision                    = var.mlmd_revision
   minio_revision                   = var.minio_revision
   oidc_gatekeeper_revision         = var.oidc_gatekeeper_revision
+  oidc_gatekeeper_ca_bundle        = var.oidc_gatekeeper_ca_bundle
   pvcviewer_operator_revision      = var.pvcviewer_operator_revision
   tensorboard_controller_revision  = var.tensorboard_controller_revision
   tensorboards_web_app_revision    = var.tensorboards_web_app_revision

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -224,6 +224,12 @@ variable "no_proxy" {
   default     = ""
 }
 
+variable "oidc_gatekeeper_ca_bundle" {
+  description = "Custom CA to be trusted by OIDC gatekeeper"
+  type        = string
+  default     = ""
+}
+
 variable "public_url" {
   description = "Public URL of Kubeflow for auth/OIDC"
   type        = string

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -291,8 +291,11 @@ module "minio" {
 module "oidc_gatekeeper" {
   source     = "git::https://github.com/canonical/oidc-gatekeeper-operator//terraform?ref=track/ckf-1.10"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
-  revision   = var.oidc_gatekeeper_revision
-  channel    = "ckf-1.10/${var.risk}"
+  config = {
+    ca-bundle = var.oidc_gatekeeper_ca_bundle,
+  }
+  revision = var.oidc_gatekeeper_revision
+  channel  = "ckf-1.10/${var.risk}"
 }
 
 module "pvcviewer_operator" {

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -145,6 +145,12 @@ variable "mlmd_size" {
   default     = "10G"
 }
 
+variable "oidc_gatekeeper_ca_bundle" {
+  description = "Custom CA to be trusted by OIDC gatekeeper"
+  type        = string
+  default     = ""
+}
+
 variable "no_proxy" {
   description = "Value of the no_proxy environment variable"
   type        = string


### PR DESCRIPTION
Hello team,

This PR adds the  `ca-bundle` charm config option for the `oidc-gatekeeper` charm