### PR TITLE
feat: add istio_ingressgateway_annotations config to enable customisation for ingress via cloud providers and fix: change in mysql-k8s-operator references to adhere to the changes in the upstream

### DIFF
--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -30,6 +30,7 @@ module "kubeflow" {
   dex_auth_revision                = var.dex_auth_revision
   envoy_revision                   = var.envoy_revision
   istio_ingressgateway_revision    = var.istio_ingressgateway_revision
+  istio_ingressgateway_annotations = var.istio_ingressgateway_annotations
   istio_pilot_revision             = var.istio_pilot_revision
   jupyter_controller_revision      = var.jupyter_controller_revision
   jupyter_ui_revision              = var.jupyter_ui_revision

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -272,6 +272,12 @@ variable "istio_ingressgateway_revision" {
   default     = null
 }
 
+variable "istio_ingressgateway_annotations" {
+  description = "A comma-separated list of annotations to apply to the Ingress Service to enable customisation for cloud providers or integrations."
+  type        = string
+  default     = ""
+}
+
 variable "istio_pilot_revision" {
   description = "Charm revision for istio-pilot"
   type        = number

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -84,7 +84,7 @@ module "katib_controller" {
 module "katib_db" {
   # tflint-ignore: terraform_module_pinned_source
   source          = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=main"
-  juju_model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name        = "katib-db"
   channel         = "8.0/stable"
   # The following config is equivalent to "constraints: mem=2G"
@@ -122,7 +122,7 @@ module "kfp_api" {
 module "kfp_db" {
   # tflint-ignore: terraform_module_pinned_source
   source          = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=main"
-  juju_model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name        = "kfp-db"
   channel         = "8.0/stable"
   # The following config is equivalent to "constraints: mem=2G"

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -83,10 +83,10 @@ module "katib_controller" {
 
 module "katib_db" {
   # tflint-ignore: terraform_module_pinned_source
-  source          = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=main"
+  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=93d6608632ae791bffce18e3b74816ebe26d1c5a"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
-  app_name        = "katib-db"
-  channel         = "8.0/stable"
+  app_name   = "katib-db"
+  channel    = "8.0/stable"
   # The following config is equivalent to "constraints: mem=2G"
   config = {
     profile-limit-memory = "2048"
@@ -121,10 +121,10 @@ module "kfp_api" {
 
 module "kfp_db" {
   # tflint-ignore: terraform_module_pinned_source
-  source          = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=main"
+  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=93d6608632ae791bffce18e3b74816ebe26d1c5a"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
-  app_name        = "kfp-db"
-  channel         = "8.0/stable"
+  app_name   = "kfp-db"
+  channel    = "8.0/stable"
   # The following config is equivalent to "constraints: mem=2G"
   config = {
     profile-limit-memory = "2048"

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -41,7 +41,8 @@ module "istio_ingressgateway" {
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "istio-ingressgateway"
   config = {
-    kind = "ingress",
+    kind        = "ingress",
+    annotations = var.istio_ingressgateway_annotations,
   }
   revision = var.istio_ingressgateway_revision
   channel  = "1.24/${var.risk}"

--- a/modules/kubeflow/cos_configuration.tf
+++ b/modules/kubeflow/cos_configuration.tf
@@ -321,7 +321,7 @@ resource "juju_integration" "katib_db_grafana_agent_k8s_grafana_dashboard" {
   model = var.create_model ? juju_model.kubeflow[0].name : local.model
 
   application {
-    name     = module.katib_db.application_name
+    name     = module.katib_db.app_name
     endpoint = module.katib_db.provides.grafana_dashboard
   }
 
@@ -336,7 +336,7 @@ resource "juju_integration" "katib_db_grafana_agent_k8s_metrics_endpoint" {
   model = var.create_model ? juju_model.kubeflow[0].name : local.model
 
   application {
-    name     = module.katib_db.application_name
+    name     = module.katib_db.app_name
     endpoint = module.katib_db.provides.metrics_endpoint
   }
 
@@ -351,7 +351,7 @@ resource "juju_integration" "katib_db_grafana_agent_k8s_grafana_logging" {
   model = var.create_model ? juju_model.kubeflow[0].name : local.model
 
   application {
-    name     = module.katib_db.application_name
+    name     = module.katib_db.app_name
     endpoint = module.katib_db.requires.logging
   }
 
@@ -442,7 +442,7 @@ resource "juju_integration" "kfp_db_grafana_agent_k8s_grafana_dashboard" {
   model = var.create_model ? juju_model.kubeflow[0].name : local.model
 
   application {
-    name     = module.kfp_db.application_name
+    name     = module.kfp_db.app_name
     endpoint = module.kfp_db.provides.grafana_dashboard
   }
 
@@ -457,7 +457,7 @@ resource "juju_integration" "kfp_db_grafana_agent_k8s_metrics_endpoint" {
   model = var.create_model ? juju_model.kubeflow[0].name : local.model
 
   application {
-    name     = module.kfp_db.application_name
+    name     = module.kfp_db.app_name
     endpoint = module.kfp_db.provides.metrics_endpoint
   }
 
@@ -472,7 +472,7 @@ resource "juju_integration" "kfp_db_grafana_agent_k8s_grafana_logging" {
   model = var.create_model ? juju_model.kubeflow[0].name : local.model
 
   application {
-    name     = module.kfp_db.application_name
+    name     = module.kfp_db.app_name
     endpoint = module.kfp_db.requires.logging
   }
 

--- a/modules/kubeflow/integrations.tf
+++ b/modules/kubeflow/integrations.tf
@@ -246,7 +246,7 @@ resource "juju_integration" "katib_db_manager_katib_db_relational_db" {
   }
 
   application {
-    name     = module.katib_db.application_name
+    name     = module.katib_db.app_name
     endpoint = module.katib_db.provides.database
   }
 }
@@ -260,7 +260,7 @@ resource "juju_integration" "kfp_api_kfp_db_database" {
   }
 
   application {
-    name     = module.kfp_db.application_name
+    name     = module.kfp_db.app_name
     endpoint = module.kfp_db.provides.database
   }
 }

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -199,6 +199,12 @@ variable "istio_ingressgateway_revision" {
   default     = null
 }
 
+variable "istio_ingressgateway_annotations" {
+  description = "A comma-separated list of annotations to apply to the Ingress Service to enable customisation for cloud providers or integrations."
+  type        = string
+  default     = ""
+}
+
 variable "istio_pilot_revision" {
   description = "Charm revision for istio-pilot"
   type        = number


### PR DESCRIPTION
mysql-k8s-operator has recently changed:
https://github.com/canonical/mysql-k8s-operator/commit/93d6608632ae791bffce18e3b74816ebe26d1c5a

so this PR addresses those changes. For CI to pass, first the PR https://github.com/canonical/charmed-mlflow-solutions/pull/21 on https://github.com/canonical/charmed-mlflow-solutions repo should be merged.