### PR TITLE
fix: set null default argument for istio annotation

### DIFF
--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -60,7 +60,7 @@ module "kubeflow" {
 }
 
 module "mlflow" {
-  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=wip-fix-trusting-issues"
+  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=track/2.15"
   # kubeflow module creates the model
   create_model                = false
   model                       = module.kubeflow.model

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -60,7 +60,7 @@ module "kubeflow" {
 }
 
 module "mlflow" {
-  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=track/2.15"
+  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=wip-fix-trusting-issues"
   # kubeflow module creates the model
   create_model                = false
   model                       = module.kubeflow.model

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -189,7 +189,7 @@ variable "istio_ingressgateway_revision" {
 variable "istio_ingressgateway_annotations" {
   description = "A comma-separated list of annotations to apply to the Ingress Service to enable customisation for cloud providers or integrations."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "istio_pilot_revision" {

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -80,7 +80,7 @@ module "katib_controller" {
 
 module "katib_db" {
   # tflint-ignore: terraform_module_pinned_source
-  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=93d6608632ae791bffce18e3b74816ebe26d1c5a"
+  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "katib-db"
   channel    = "8.0/stable"
@@ -115,7 +115,7 @@ module "kfp_api" {
 
 module "kfp_db" {
   # tflint-ignore: terraform_module_pinned_source
-  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=93d6608632ae791bffce18e3b74816ebe26d1c5a"
+  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "kfp-db"
   channel    = "8.0/stable"

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -152,7 +152,7 @@ variable "istio_ingressgateway_revision" {
 variable "istio_ingressgateway_annotations" {
   description = "A comma-separated list of annotations to apply to the Ingress Service to enable customisation for cloud providers or integrations."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "istio_pilot_revision" {


### PR DESCRIPTION
Providing empty values seems to be breaking some existing deployments. See #72 

Companion of #75 