### PR TITLE
Remove configs that are nulls

### DIFF
--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -33,13 +33,19 @@ module "envoy" {
   channel    = "2.2/${var.risk}"
 }
 
+locals {
+  istio_ingressgateway_config = {
+    kind        = "ingress",
+    annotations = var.istio_ingressgateway_annotations,
+  }
+}
 module "istio_ingressgateway" {
   source     = "git::https://github.com/canonical/istio-operators//charms/istio-gateway/terraform?ref=track/1.22"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "istio-ingressgateway"
   config = {
-    kind        = "ingress",
-    annotations = var.istio_ingressgateway_annotations,
+    for key,value in local.istio_ingressgateway_config : key => value
+    if value != null
   }
   revision = var.istio_ingressgateway_revision
   channel  = "1.22/${var.risk}"


### PR DESCRIPTION
Fixes #72

This is one idea to try and handle nulls in the config. However, alternatives might be better:
- removing the config altogether (but this would not allow it to be added in later)
- using map merges instead of a filter
- a more standardised method for `juju_application` configs that I'm probably not aware of.