### PR TITLE
Expose config option for `kubeflow_profiles` security policy

### DIFF
--- a/.github/workflows/deploy-to-microk8s.yaml
+++ b/.github/workflows/deploy-to-microk8s.yaml
@@ -8,6 +8,7 @@ on:
       uats_branch:
         description: 'Branch to run the UATs from e.g. main or track/1.10. By default, this is defined by the dependencies.yaml file.'
         required: false
+        default: "track/1.10"
       ckf_branch:
         description: 'Branch on the Charmed Kubeflow repository to be tested'
         required: false
@@ -77,7 +78,7 @@ jobs:
           juju-channel: "3.6/stable"
           charmcraft-channel: "3.x/stable"
           provider: microk8s
-          channel: ${{ format('{0}-strict/stable', env.K8S_VERSION) }}
+          channel: "1.32-strict/stable"
           microk8s-group: snap_microk8s
           microk8s-addons: "rbac dns hostpath-storage metallb:10.64.140.43-10.64.140.49"
           bootstrap-options: "--agent-version 3.6.9"
@@ -100,7 +101,7 @@ jobs:
           git clone https://github.com/canonical/charmed-kubeflow-uats.git ~/charmed-kubeflow-uats
           cd ~/charmed-kubeflow-uats
           git checkout ${{ env.UATS_BRANCH }}
-          tox -e ${{ matrix.bundle.uats.env }} -- ${{ matrix.bundle.uats.extra-args }}
+          tox -e ${{ matrix.bundle.uats.env }} -- --bundle "" ${{ matrix.bundle.uats.extra-args }}
 
       # On failure, capture debugging resources
       - name: Select model

--- a/modules/kubeflow-feast/README.md
+++ b/modules/kubeflow-feast/README.md
@@ -21,10 +21,13 @@ The solution module offers the following configurable inputs:
 | `grafana_agent_k8s_size`| string | Grafana agent database storage size | False |
 | `http_proxy`| string | Value of the http_proxy environment variable | False |
 | `https_proxy`| string | Value of the https_proxy environment variable | False |
+| `istio_cni_bin_dir`| string | Path to CNI binaries, e.g. /opt/cni/bin. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path. | False |
+| `istio_cni_conf_dir`| string | Path to conflist files describing the CNI configuration, e.g. /etc/cni/net.d. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path. | False |
 | `istio_tls_secret_id`| string | The juju secret id for the tls key/cert for istio-pilot | False |
 | `jupyter_ui_config`| map(string) | Map of config values passed to jupyter-ui | False |
 | `katib_db_size`| string | Katib database storage size | False |
 | `kfp_db_size`| string | KFP database storage size | False |
+| `kubeflow_profiles_security_policy`| string | Security policy for pod security standards enforced in user workloads. Only `privileged` and `baseline` are supported | False |
 | `minio_size`| string | MinIO database storage size | False |
 | `mlmd_size`| string | MLMD database storage size | False |
 | `no_proxy`| string | Value of the no_proxy environment variable | False |

--- a/modules/kubeflow-feast/main.tf
+++ b/modules/kubeflow-feast/main.tf
@@ -10,10 +10,13 @@ module "kubeflow" {
   grafana_agent_k8s_size           = var.grafana_agent_k8s_size
   http_proxy                       = var.http_proxy
   https_proxy                      = var.https_proxy
+  istio_cni_bin_dir = var.istio_cni_bin_dir
+  istio_cni_conf_dir = var.istio_cni_conf_dir
   istio_tls_secret_id              = var.istio_tls_secret_id
   jupyter_ui_config                = var.jupyter_ui_config
   katib_db_size                    = var.katib_db_size
   kfp_db_size                      = var.kfp_db_size
+  kubeflow_profiles_security_policy = var.kubeflow_profiles_security_policy
   minio_size                       = var.minio_size
   mlmd_size                        = var.mlmd_size
   no_proxy                         = var.no_proxy

--- a/modules/kubeflow-feast/variables.tf
+++ b/modules/kubeflow-feast/variables.tf
@@ -65,6 +65,18 @@ variable "https_proxy" {
   default     = ""
 }
 
+variable "istio_cni_bin_dir" {
+  description = "Path to CNI binaries, e.g. /opt/cni/bin. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path."
+  type        = string
+  default     = ""
+}
+
+variable "istio_cni_conf_dir" {
+  description = "Path to conflist files describing the CNI configuration, e.g. /etc/cni/net.d. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path."
+  type        = string
+  default     = ""
+}
+
 variable "istio_tls_secret_id" {
   description = "The juju secret id for the tls key/cert for istio-pilot"
   type        = string
@@ -87,6 +99,17 @@ variable "kfp_db_size" {
   description = "KFP database storage size"
   type        = string
   default     = "10G"
+}
+
+variable "kubeflow_profiles_security_policy" {
+  description = "Security policy for pod security standards enforced in user workloads. Only `privileged` and `baseline` are supported"
+  type        = string
+  default     = "privileged"
+
+  validation {
+    condition     = var.kubeflow_profiles_security_policy == "privileged" || var.kubeflow_profiles_security_policy == "baseline"
+    error_message = "The variable must be one of 'privileged' or 'baseline'."
+  }
 }
 
 variable "minio_size" {

--- a/modules/kubeflow-mlflow/README.md
+++ b/modules/kubeflow-mlflow/README.md
@@ -21,11 +21,14 @@ The solution module offers the following configurable inputs:
 | `existing_grafana_agent_name`| string | Name of an existing grafana-agent-k8s deployment | False |
 | `grafana_agent_k8s_size`| string | Grafana agent database storage size | False |
 | `http_proxy`| string | Value of the http_proxy environment variable | False |
+| `istio_cni_bin_dir`| string | Path to CNI binaries, e.g. /opt/cni/bin. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path. | False |
+| `istio_cni_conf_dir`| string | Path to conflist files describing the CNI configuration, e.g. /etc/cni/net.d. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path. | False |
 | `https_proxy`| string | Value of the https_proxy environment variable | False |
 | `istio_tls_secret_id`| string | The juju secret id for the tls key/cert for istio-pilot | False |
 | `jupyter_ui_config`| map(string) | Map of config values passed to jupyter-ui | False |
 | `katib_db_size`| string | Katib database storage size | False |
 | `kfp_db_size`| string | KFP database storage size | False |
+| `kubeflow_profiles_security_policy`| string | Security policy for pod security standards enforced in user workloads. Only `privileged` and `baseline` are supported | False |
 | `minio_size`| string | MinIO database storage size | False |
 | `mlflow_dashboard_link`| bool | Boolean value that enables MLflow link in Kubeflow's dashboard | False |
 | `mlflow_kserve_integration` | bool | Boolean value that integrates MLflow with KServe | False |

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -11,11 +11,14 @@ module "kubeflow" {
   grafana_agent_k8s_size               = var.grafana_agent_k8s_size
   http_proxy                           = var.http_proxy
   https_proxy                          = var.https_proxy
+  istio_cni_bin_dir                    = var.istio_cni_bin_dir
+  istio_cni_conf_dir                   = var.istio_cni_conf_dir
   istio_tls_secret_id                  = var.istio_tls_secret_id
   jupyter_ui_config                    = var.jupyter_ui_config
   katib_db_size                        = var.katib_db_size
   kfp_api_object_store_bucket_name     = var.kfp_api_object_store_bucket_name
   kfp_db_size                          = var.kfp_db_size
+  kubeflow_profiles_security_policy    = var.kubeflow_profiles_security_policy
   minio_access_key                     = var.minio_access_key
   minio_gateway_storage_service        = var.minio_gateway_storage_service
   minio_mode                           = var.minio_mode

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -77,6 +77,18 @@ variable "https_proxy" {
   default     = ""
 }
 
+variable "istio_cni_bin_dir" {
+  description = "Path to CNI binaries, e.g. /opt/cni/bin. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path."
+  type        = string
+  default     = ""
+}
+
+variable "istio_cni_conf_dir" {
+  description = "Path to conflist files describing the CNI configuration, e.g. /etc/cni/net.d. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path."
+  type        = string
+  default     = ""
+}
+
 variable "istio_tls_secret_id" {
   description = "The juju secret id for the tls key/cert for istio-pilot"
   type        = string
@@ -105,6 +117,17 @@ variable "kfp_db_size" {
   description = "KFP database storage size"
   type        = string
   default     = "10G"
+}
+
+variable "kubeflow_profiles_security_policy" {
+  description = "Security policy for pod security standards enforced in user workloads. Only `privileged` and `baseline` are supported"
+  type        = string
+  default     = "privileged"
+
+  validation {
+    condition     = var.kubeflow_profiles_security_policy == "privileged" || var.kubeflow_profiles_security_policy == "baseline"
+    error_message = "The variable must be one of 'privileged' or 'baseline'."
+  }
 }
 
 variable "minio_access_key" {

--- a/modules/kubeflow/README.md
+++ b/modules/kubeflow/README.md
@@ -25,6 +25,7 @@ The solution module offers the following configurable inputs:
 | `jupyter_ui_config`| map(string) | Map of config values passed to jupyter-ui | False |
 | `katib_db_size`| string | Katib database storage size | False |
 | `kfp_db_size`| string | KFP database storage size | False |
+| `kubeflow_profiles_security_policy`| string | Security policy for pod security standards enforced in user workloads. Only `privileged` and `baseline` are supported | False |
 | `minio_size`| string | MinIO database storage size | False |
 | `mlmd_size`| string | MLMD database storage size | False |
 | `no_proxy`| string | Value of the no_proxy environment variable | False |

--- a/modules/kubeflow/README.md
+++ b/modules/kubeflow/README.md
@@ -21,6 +21,8 @@ The solution module offers the following configurable inputs:
 | `grafana_agent_k8s_size`| string | Grafana agent database storage size | False |
 | `http_proxy`| string | Value of the http_proxy environment variable | False |
 | `https_proxy`| string | Value of the https_proxy environment variable | False |
+| `istio_cni_bin_dir`| string | Path to CNI binaries, e.g. /opt/cni/bin. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path. | False |
+| `istio_cni_conf_dir`| string | Path to conflist files describing the CNI configuration, e.g. /etc/cni/net.d. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path. | False |
 | `istio_tls_secret_id`| string | The juju secret id for the tls key/cert for istio-pilot | False |
 | `jupyter_ui_config`| map(string) | Map of config values passed to jupyter-ui | False |
 | `katib_db_size`| string | Katib database storage size | False |

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -240,7 +240,7 @@ module "kubeflow_dashboard" {
 module "kubeflow_profiles" {
   source     = "git::https://github.com/canonical/kubeflow-profiles-operator//terraform?ref=track/1.10"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
-  config {
+  config = {
 	"security-policy" : var.kubeflow_profiles_security_policy
   }
   revision   = var.kubeflow_profiles_revision

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -238,7 +238,7 @@ module "kubeflow_dashboard" {
 }
 
 module "kubeflow_profiles" {
-  source     = "git::https://github.com/canonical/kubeflow-profiles-operator//terraform?ref=main"
+  source     = "git::https://github.com/canonical/kubeflow-profiles-operator//terraform?ref=track/1.10"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   config = {
     "security-policy" : var.kubeflow_profiles_security_policy

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -53,6 +53,8 @@ module "istio_pilot" {
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   config = {
     default-gateway = "kubeflow-gateway",
+    "cni-bin-dir" : var.istio_cni_bin_dir
+    "cni-conf-dir" : var.istio_cni_conf_dir
     "tls-secret-id" : var.istio_tls_secret_id
   }
   revision = var.istio_pilot_revision

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -240,6 +240,9 @@ module "kubeflow_dashboard" {
 module "kubeflow_profiles" {
   source     = "git::https://github.com/canonical/kubeflow-profiles-operator//terraform?ref=track/1.10"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  config {
+	"security-policy" : var.kubeflow_profiles_security_policy
+  }
   revision   = var.kubeflow_profiles_revision
   channel    = "1.10/${var.risk}"
 }

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -238,13 +238,13 @@ module "kubeflow_dashboard" {
 }
 
 module "kubeflow_profiles" {
-  source     = "git::https://github.com/canonical/kubeflow-profiles-operator//terraform?ref=track/1.10"
+  source     = "git::https://github.com/canonical/kubeflow-profiles-operator//terraform?ref=main"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   config = {
     "security-policy" : var.kubeflow_profiles_security_policy
   }
   revision = var.kubeflow_profiles_revision
-  channel  = "1.10/${var.risk}"
+  channel  = "latest/edge"
 }
 
 module "kubeflow_roles" {

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -241,10 +241,10 @@ module "kubeflow_profiles" {
   source     = "git::https://github.com/canonical/kubeflow-profiles-operator//terraform?ref=track/1.10"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   config = {
-	"security-policy" : var.kubeflow_profiles_security_policy
+    "security-policy" : var.kubeflow_profiles_security_policy
   }
-  revision   = var.kubeflow_profiles_revision
-  channel    = "1.10/${var.risk}"
+  revision = var.kubeflow_profiles_revision
+  channel  = "1.10/${var.risk}"
 }
 
 module "kubeflow_roles" {

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -101,6 +101,12 @@ variable "kfp_db_size" {
   default     = "10G"
 }
 
+variable "kubeflow_profiles_security_policy" {
+  description = "Pod security policy to enforce in user workloads"
+  type        = string
+  default     = "privileged"
+}
+
 variable "minio_access_key" {
   description = "MinIO access key"
   type        = string

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -71,6 +71,18 @@ variable "https_proxy" {
   default     = ""
 }
 
+variable "istio_cni_bin_dir" {
+  description = "Path to CNI binaries, e.g. /opt/cni/bin. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path."
+  type        = string
+  default     = ""
+}
+
+variable "istio_cni_conf_dir" {
+  description = "Path to conflist files describing the CNI configuration, e.g. /etc/cni/net.d. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled. This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/ for information to find out the correct path."
+  type        = string
+  default     = ""
+}
+
 variable "istio_tls_secret_id" {
   description = "The juju secret id for the tls key/cert for istio-pilot"
   type        = string

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -102,9 +102,14 @@ variable "kfp_db_size" {
 }
 
 variable "kubeflow_profiles_security_policy" {
-  description = "Pod security policy to enforce in user workloads"
+  description = "Security policy for pod security standards enforced in user workloads. Only `privileged` and `baseline` are supported"
   type        = string
   default     = "privileged"
+
+  validation {
+    condition     = var.kubeflow_profiles_security_policy == "privileged" || var.kubeflow_profiles_security_policy == "baseline"
+    error_message = "The variable must be one of 'privileged' or 'baseline'."
+  }
 }
 
 variable "minio_access_key" {


### PR DESCRIPTION
Closes #90 

This PR exposes the `security-policy` config option of `kubeflow-profiles`, that has been created in https://github.com/canonical/kubeflow-profiles-operator/pull/270.