### PR TITLE
chore: bump Kubeflow Trainer V2 to version `2.1`

### DIFF
--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -261,7 +261,7 @@ module "kubeflow_trainer" {
   source     = "git::https://github.com/canonical/training-operator//terraform?ref=track/2.0"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kubeflow_trainer_revision
-  channel    = "2.0/edge"
+  channel    = "2.1/edge"
 }
 
 module "kubeflow_volumes" {


### PR DESCRIPTION
This PR bumps channel for Kubeflow Trainer V2 to `2.0` to the latest `2.1`.