### PR TITLE
chore: Update EKS test to bypass pod limits per node

### DIFF
--- a/.github/cluster.yaml
+++ b/.github/cluster.yaml
@@ -34,6 +34,8 @@ managedNodeGroups:
   maxPodsPerNode: 110
   name: ng-d06bd84e
   releaseVersion: ""
+  ssh:
+    allow: true
   tags:
     alpha.eksctl.io/nodegroup-name: ng-d06bd84e
     alpha.eksctl.io/nodegroup-type: managed

--- a/.github/cluster.yaml
+++ b/.github/cluster.yaml
@@ -8,9 +8,11 @@ iam:
   vpcResourceControllerPolicy: true
   withOIDC: false
 addons:
+- name: eks-pod-identity-agent
 - name: aws-ebs-csi-driver
-  serviceAccountRoleARN: "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+  useDefaultPodIdentityAssociations: true
 - name: vpc-cni
+  useDefaultPodIdentityAssociations: true
   configurationValues: |
     {
       "env": {
@@ -26,13 +28,12 @@ managedNodeGroups:
   iam:
     withAddonPolicies:
       ebs: true
-  instanceType: t2.2xlarge
+  instanceType: t3.2xlarge
   maxSize: 2
   minSize: 2
+  maxPodsPerNode: 110
   name: ng-d06bd84e
   releaseVersion: ""
-  ssh:
-    allow: true
   tags:
     alpha.eksctl.io/nodegroup-name: ng-d06bd84e
     alpha.eksctl.io/nodegroup-type: managed
@@ -40,4 +41,4 @@ managedNodeGroups:
 metadata:
   name: kubeflow-test
   region: eu-central-1
-  version: "1.32"
+  version: "1.33"

--- a/.github/cluster.yaml
+++ b/.github/cluster.yaml
@@ -10,6 +10,14 @@ iam:
 addons:
 - name: aws-ebs-csi-driver
   serviceAccountRoleARN: "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+- name: vpc-cni
+  configurationValues: |
+    {
+      "env": {
+        "ENABLE_PREFIX_DELEGATION": "true",
+        "WARM_PREFIX_TARGET": "1"
+      }
+    }
 kind: ClusterConfig
 kubernetesNetworkConfig:
   ipFamily: IPv4

--- a/.github/cluster.yaml
+++ b/.github/cluster.yaml
@@ -41,4 +41,4 @@ managedNodeGroups:
 metadata:
   name: kubeflow-test
   region: eu-central-1
-  version: "1.33"
+  version: "1.32"

--- a/.github/workflows/deploy-to-eks.yaml
+++ b/.github/workflows/deploy-to-eks.yaml
@@ -70,7 +70,7 @@ jobs:
           echo "CKF_BRANCH=${CKF_BRANCH}" >> $GITHUB_ENV
           RISK=${{ inputs.risk }}
           echo "RISK=${RISK}" >> $GITHUB_ENV
-          
+
           if [[ -z "${{ inputs.uats_branch }}" ]]; then UATS_BRANCH=${UATS_BRANCH}; else UATS_BRANCH=${{ inputs.uats_branch }}; fi
           echo "UATS_BRANCH=${UATS_BRANCH}" >> $GITHUB_ENV
 
@@ -85,7 +85,7 @@ jobs:
         run: |
           pip install tox
           sudo snap install juju --channel=${{ env.JUJU_VERSION }}/stable
-          sudo snap install charmcraft --channel latest/stable --classic
+          sudo snap install charmcraft --channe=3.x/stable --classic
           sudo snap install terraform --channel=latest/stable --classic
           juju version
           terraform --version
@@ -156,7 +156,7 @@ jobs:
       - name: Setup Juju controller
         run: |
           /snap/juju/current/bin/juju add-k8s eks --client
-          juju bootstrap eks eks-controller --agent-version 3.6.9
+          juju bootstrap eks eks-controller
 
       - name: Deploy and assert solution
         env:
@@ -232,5 +232,5 @@ jobs:
       needs: [deploy-solution-to-eks]
       uses: ./.github/workflows/delete-aws-volumes.yaml
       with:
-        region: ${{ needs.deploy-solution-to-eks.outputs.aws_region }}  
+        region: ${{ needs.deploy-solution-to-eks.outputs.aws_region }}
       secrets: inherit

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -85,7 +85,7 @@ module "katib_controller" {
 
 module "katib_db" {
   # tflint-ignore: terraform_module_pinned_source
-  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=0088c9583f63999ff37d982948e47b9e3e3fba2a"
+  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "katib-db"
   channel    = "8.0/stable"
@@ -123,7 +123,7 @@ module "kfp_api" {
 
 module "kfp_db" {
   # tflint-ignore: terraform_module_pinned_source
-  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=0088c9583f63999ff37d982948e47b9e3e3fba2a"
+  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "kfp-db"
   channel    = "8.0/stable"

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -85,7 +85,7 @@ module "katib_controller" {
 
 module "katib_db" {
   # tflint-ignore: terraform_module_pinned_source
-  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
+  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=0088c9583f63999ff37d982948e47b9e3e3fba2a"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "katib-db"
   channel    = "8.0/stable"
@@ -123,7 +123,7 @@ module "kfp_api" {
 
 module "kfp_db" {
   # tflint-ignore: terraform_module_pinned_source
-  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
+  source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=0088c9583f63999ff37d982948e47b9e3e3fba2a"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "kfp-db"
   channel    = "8.0/stable"

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -88,7 +88,7 @@ module "katib_db" {
   source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "katib-db"
-  channel    = "8.0/stable"
+  channel    = "8.0/edge"
   # The following config is equivalent to "constraints: mem=2G"
   config = {
     profile-limit-memory = "2048"
@@ -126,7 +126,7 @@ module "kfp_db" {
   source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "kfp-db"
-  channel    = "8.0/stable"
+  channel    = "8.0/edge"
   # The following config is equivalent to "constraints: mem=2G"
   config = {
     profile-limit-memory = "2048"

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -88,7 +88,7 @@ module "katib_db" {
   source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "katib-db"
-  channel    = "8.0/edge"
+  channel    = "8.0/stable"
   # The following config is equivalent to "constraints: mem=2G"
   config = {
     profile-limit-memory = "2048"
@@ -126,7 +126,7 @@ module "kfp_db" {
   source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   app_name   = "kfp-db"
-  channel    = "8.0/edge"
+  channel    = "8.0/stable"
   # The following config is equivalent to "constraints: mem=2G"
   config = {
     profile-limit-memory = "2048"


### PR DESCRIPTION
Closes #101

This PR updates the `deploy-to-eks.yaml` action, as well as the `cluster.yaml` file to deploy the EKS cluster. The new file uses the prefix assignment mode in the VPC CNI plugin, in order to increase the maximum number of pods per node. More details can be found in [this exploration comment](https://github.com/canonical/charmed-kubeflow-solutions/issues/101#issuecomment-3871210890)

# Notes
- We use a Nitro hypervisor based instance type (`t3.2xlarge`) since prefix delegation is not available in Xen hypervisor instance types.
- We use the newer [Pod Security Associations](https://docs.aws.amazon.com/eks/latest/eksctl/pod-identity-associations.html) to get the proper permissions to configure the add ons.
- We setup the environment variables `ENABLE_PREFIX_DELEGATION` and `WARM_PREFIX_TARGET` according to the best practices explained in https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/
- We pin the `3.x` channel of `charmcraft` to align the version we use in all other repositories.
- We unpin the patch version of the Juju agent we use from `3.6.9`