### PR TITLE
[DO NOT MERGE] fix: remove depracated knative namespace configs

### DIFF
--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -187,9 +187,6 @@ module "kfp_viz" {
 module "knative_eventing" {
   source     = "git::https://github.com/canonical/knative-operators//charms/knative-eventing/terraform?ref=track/1.16"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
-  config = {
-    namespace = "knative-eventing"
-  }
   revision = var.knative_eventing_revision
   channel  = "1.16/${var.risk}"
 }
@@ -209,7 +206,6 @@ module "knative_serving" {
     https-proxy               = var.https_proxy,
     "istio.gateway.namespace" = local.model,
     "istio.gateway.name"      = "kubeflow-gateway",
-    namespace                 = "knative-serving",
     no-proxy                  = var.no_proxy,
   }
   revision = var.knative_serving_revision


### PR DESCRIPTION
**Note:** We cannot merge this until we release knative to `0.16/stable`, the reason it is affecting spark solution now is because that one is deploying kubeflow `1.10/edge`

Closes #131 