### PR TITLE
[DO NOT MERGE] test: impose `baseline` PSS on platform namespace

### DIFF
--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -139,6 +139,9 @@ jobs:
             RISK_ARG=""
           fi
 
+          juju add-model istio-system
+          juju add-model kubeflow
+          kubectl label namespaces kubeflow pod-security.kubernetes.io/enforce=baseline
           tox -c ./modules/${{ matrix.bundle.module }} -e test_deployment -- -vv -s $RISK_ARG $TF_VARS_ARG $ISTIO_PLATFORM_ARG
 
       - name: Run UATs

--- a/.github/workflows/deploy-to-microk8s.yaml
+++ b/.github/workflows/deploy-to-microk8s.yaml
@@ -171,6 +171,9 @@ jobs:
             RISK_ARG=""
           fi
 
+          juju add-model istio-system
+          juju add-model kubeflow
+          kubectl label namespaces kubeflow pod-security.kubernetes.io/enforce=baseline
           tox -c ./modules/${{ matrix.bundle.module }} -e test_deployment -- -vv -s $RISK_ARG $CNI_ARGS --pss ${{ matrix.pod-security-standards.policy }} $TF_VARS_ARG
 
       - name: Run UATs

--- a/modules/kubeflow-ambient/applications.tf
+++ b/modules/kubeflow-ambient/applications.tf
@@ -1,14 +1,14 @@
 
 module "admission_webhook" {
   source     = "git::https://github.com/canonical/admission-webhook-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.admission_webhook_revision
   channel    = "latest/edge"
 }
 
 module "argo_controller" {
   source     = "git::https://github.com/canonical/argo-operators//charms/argo-controller/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.argo_controller_revision
   channel    = "latest/edge"
   config = {
@@ -18,7 +18,7 @@ module "argo_controller" {
 
 module "dex_auth" {
   source     = "git::https://github.com/canonical/dex-auth-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   config = {
     "public-url" : var.public_url,
     "connectors" : var.dex_connectors
@@ -31,21 +31,21 @@ module "dex_auth" {
 
 module "envoy" {
   source     = "git::https://github.com/canonical/envoy-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.envoy_revision
   channel    = "latest/edge"
 }
 
 module "jupyter_controller" {
   source     = "git::https://github.com/canonical/notebook-operators//charms/jupyter-controller/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.jupyter_controller_revision
   channel    = "latest/edge"
 }
 
 module "jupyter_ui" {
   source     = "git::https://github.com/canonical/notebook-operators//charms/jupyter-ui/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   config     = var.jupyter_ui_config
   revision   = var.jupyter_ui_revision
   channel    = "latest/edge"
@@ -53,7 +53,7 @@ module "jupyter_ui" {
 
 module "katib_controller" {
   source     = "git::https://github.com/canonical/katib-operators//charms/katib-controller/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.katib_controller_revision
   channel    = "latest/edge"
 }
@@ -61,7 +61,7 @@ module "katib_controller" {
 module "katib_db" {
   # tflint-ignore: terraform_module_pinned_source
   source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   app_name   = "katib-db"
   channel    = "8.0/stable"
   # The following config is equivalent to "constraints: mem=2G"
@@ -74,21 +74,21 @@ module "katib_db" {
 
 module "katib_db_manager" {
   source     = "git::https://github.com/canonical/katib-operators//charms/katib-db-manager/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.katib_db_manager_revision
   channel    = "latest/edge"
 }
 
 module "katib_ui" {
   source     = "git::https://github.com/canonical/katib-operators//charms/katib-ui/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.katib_ui_revision
   channel    = "latest/edge"
 }
 
 module "kfp_api" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-api/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.kfp_api_revision
   config = {
     object-store-bucket-name = var.kfp_api_object_store_bucket_name
@@ -99,7 +99,7 @@ module "kfp_api" {
 module "kfp_db" {
   # tflint-ignore: terraform_module_pinned_source
   source     = "git::https://github.com/canonical/mysql-k8s-operator//terraform?ref=eb6261e6fd1830d80aa4fa260d091c9110c24ba4"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   app_name   = "kfp-db"
   channel    = "8.0/stable"
   # The following config is equivalent to "constraints: mem=2G"
@@ -112,56 +112,56 @@ module "kfp_db" {
 
 module "kfp_metadata_writer" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-metadata-writer/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.kfp_metadata_writer_revision
   channel    = "latest/edge"
 }
 
 module "kfp_persistence" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-persistence/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.kfp_persistence_revision
   channel    = "latest/edge"
 }
 
 module "kfp_profile_controller" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-profile-controller/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.kfp_profile_controller_revision
   channel    = "latest/edge"
 }
 
 module "kfp_schedwf" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-schedwf/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.kfp_schedwf_revision
   channel    = "latest/edge"
 }
 
 module "kfp_ui" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-ui/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.kfp_ui_revision
   channel    = "latest/edge"
 }
 
 module "kfp_viewer" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-viewer/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.kfp_viewer_revision
   channel    = "latest/edge"
 }
 
 module "kfp_viz" {
   source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-viz/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.kfp_viz_revision
   channel    = "latest/edge"
 }
 
 module "kserve_controller" {
   source     = "git::https://github.com/canonical/kserve-operators//charms/kserve-controller/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   config = {
     deployment-mode = "rawdeployment",
     http-proxy      = var.http_proxy,
@@ -174,7 +174,7 @@ module "kserve_controller" {
 
 module "kubeflow_dashboard" {
   source     = "git::https://github.com/canonical/kubeflow-dashboard-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   config = {
     "registration-flow" : var.kubeflow_dashboard_registration_flow
   }
@@ -184,7 +184,7 @@ module "kubeflow_dashboard" {
 
 module "kubeflow_profiles" {
   source     = "git::https://github.com/canonical/kubeflow-profiles-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   config = {
     "security-policy" : var.kubeflow_profiles_security_policy
     "service-mesh-mode" : "istio-ambient"
@@ -196,7 +196,7 @@ module "kubeflow_profiles" {
 
 module "kubeflow_roles" {
   source     = "git::https://github.com/canonical/kubeflow-roles-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.kubeflow_roles_revision
   channel    = "latest/edge"
 }
@@ -204,28 +204,28 @@ module "kubeflow_roles" {
 module "kubeflow_trainer" {
   count      = var.kubeflow_trainer_v2 ? 1 : 0
   source     = "git::https://github.com/canonical/training-operator//terraform?ref=main-v2"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.kubeflow_trainer_revision
   channel    = "latest/edge"
 }
 
 module "kubeflow_volumes" {
   source     = "git::https://github.com/canonical/kubeflow-volumes-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.kubeflow_volumes_revision
   channel    = "latest/edge"
 }
 
 module "metacontroller_operator" {
   source     = "git::https://github.com/canonical/metacontroller-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.metacontroller_operator_revision
   channel    = "latest/edge"
 }
 
 module "mlmd" {
   source     = "git::https://github.com/canonical/mlmd-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   storage_directives = {
     mlmd-data = var.mlmd_size
   }
@@ -235,7 +235,7 @@ module "mlmd" {
 
 module "minio" {
   source     = "git::https://github.com/canonical/minio-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   config = {
     access-key               = var.minio_access_key,
     secret-key               = var.minio_secret_key,
@@ -252,7 +252,7 @@ module "minio" {
 
 module "oidc_gatekeeper" {
   source     = "git::https://github.com/canonical/oidc-gatekeeper-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   config = {
     ca-bundle = var.oidc_gatekeeper_ca_bundle,
   }
@@ -262,35 +262,35 @@ module "oidc_gatekeeper" {
 
 module "pvcviewer_operator" {
   source     = "git::https://github.com/canonical/pvcviewer-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.pvcviewer_operator_revision
   channel    = "latest/edge"
 }
 
 module "tensorboard_controller" {
   source     = "git::https://github.com/canonical/kubeflow-tensorboards-operator//charms/tensorboard-controller/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.tensorboard_controller_revision
   channel    = "latest/edge"
 }
 
 module "tensorboards_web_app" {
   source     = "git::https://github.com/canonical/kubeflow-tensorboards-operator//charms/tensorboards-web-app/terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.tensorboards_web_app_revision
   channel    = "latest/edge"
 }
 
 module "training_operator" {
   source     = "git::https://github.com/canonical/training-operator//terraform?ref=main"
-  model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model_name = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   revision   = var.training_operator_revision
   channel    = "latest/edge"
 }
 
 resource "juju_application" "istio_k8s" {
   name  = "istio-k8s"
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.istio[0].name : local.istio_system_model
   trust = true
   config = {
     platform = var.istio_k8s_platform
@@ -305,7 +305,7 @@ resource "juju_application" "istio_k8s" {
 
 resource "juju_application" "istio_ingress_k8s" {
   name  = "istio-ingress-k8s"
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   trust = true
 
   charm {
@@ -317,7 +317,7 @@ resource "juju_application" "istio_ingress_k8s" {
 
 resource "juju_application" "istio_beacon_k8s" {
   name  = "istio-beacon-k8s"
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   trust = true
 
   charm {

--- a/modules/kubeflow-ambient/cos_configuration.tf
+++ b/modules/kubeflow-ambient/cos_configuration.tf
@@ -7,7 +7,7 @@ resource "juju_application" "opentelemetry_collector_k8s" {
     channel  = "2/stable"
     revision = var.opentelemetry_collector_k8s_revision
   }
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
   name  = "opentelemetry-collector-k8s-kubeflow"
   storage_directives = {
     persisted = var.opentelemetry_collector_k8s_size
@@ -18,7 +18,7 @@ resource "juju_application" "opentelemetry_collector_k8s" {
 
 resource "juju_integration" "argo_controller_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.argo_controller.app_name
@@ -33,7 +33,7 @@ resource "juju_integration" "argo_controller_opentelemetry_collector_k8s_grafana
 
 resource "juju_integration" "argo_controller_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.argo_controller.app_name
@@ -48,7 +48,7 @@ resource "juju_integration" "argo_controller_opentelemetry_collector_k8s_metrics
 
 resource "juju_integration" "argo_controller_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.argo_controller.app_name
@@ -63,7 +63,7 @@ resource "juju_integration" "argo_controller_opentelemetry_collector_k8s_grafana
 
 resource "juju_integration" "admission_webhook_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.admission_webhook.app_name
@@ -78,7 +78,7 @@ resource "juju_integration" "admission_webhook_opentelemetry_collector_k8s_grafa
 
 resource "juju_integration" "dex_auth_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.dex_auth.app_name
@@ -93,7 +93,7 @@ resource "juju_integration" "dex_auth_opentelemetry_collector_k8s_grafana_dashbo
 
 resource "juju_integration" "dex_auth_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.dex_auth.app_name
@@ -108,7 +108,7 @@ resource "juju_integration" "dex_auth_opentelemetry_collector_k8s_metrics_endpoi
 
 resource "juju_integration" "dex_auth_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.dex_auth.app_name
@@ -123,7 +123,7 @@ resource "juju_integration" "dex_auth_opentelemetry_collector_k8s_grafana_loggin
 
 resource "juju_integration" "envoy_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.envoy.app_name
@@ -138,7 +138,7 @@ resource "juju_integration" "envoy_opentelemetry_collector_k8s_grafana_dashboard
 
 resource "juju_integration" "envoy_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.envoy.app_name
@@ -153,7 +153,7 @@ resource "juju_integration" "envoy_opentelemetry_collector_k8s_metrics_endpoint"
 
 resource "juju_integration" "envoy_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.envoy.app_name
@@ -168,7 +168,7 @@ resource "juju_integration" "envoy_opentelemetry_collector_k8s_grafana_logging" 
 
 resource "juju_integration" "jupyter_controller_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.jupyter_controller.app_name
@@ -183,7 +183,7 @@ resource "juju_integration" "jupyter_controller_opentelemetry_collector_k8s_graf
 
 resource "juju_integration" "jupyter_controller_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.jupyter_controller.app_name
@@ -198,7 +198,7 @@ resource "juju_integration" "jupyter_controller_opentelemetry_collector_k8s_metr
 
 resource "juju_integration" "jupyter_controller_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.jupyter_controller.app_name
@@ -213,7 +213,7 @@ resource "juju_integration" "jupyter_controller_opentelemetry_collector_k8s_graf
 
 resource "juju_integration" "jupyter_ui_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.jupyter_ui.app_name
@@ -228,7 +228,7 @@ resource "juju_integration" "jupyter_ui_opentelemetry_collector_k8s_grafana_logg
 
 resource "juju_integration" "katib_controller_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.katib_controller.app_name
@@ -243,7 +243,7 @@ resource "juju_integration" "katib_controller_opentelemetry_collector_k8s_grafan
 
 resource "juju_integration" "katib_controller_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.katib_controller.app_name
@@ -258,7 +258,7 @@ resource "juju_integration" "katib_controller_opentelemetry_collector_k8s_metric
 
 resource "juju_integration" "katib_controller_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.katib_controller.app_name
@@ -273,7 +273,7 @@ resource "juju_integration" "katib_controller_opentelemetry_collector_k8s_grafan
 
 resource "juju_integration" "katib_db_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.katib_db.app_name
@@ -288,7 +288,7 @@ resource "juju_integration" "katib_db_opentelemetry_collector_k8s_grafana_dashbo
 
 resource "juju_integration" "katib_db_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.katib_db.app_name
@@ -303,7 +303,7 @@ resource "juju_integration" "katib_db_opentelemetry_collector_k8s_metrics_endpoi
 
 resource "juju_integration" "katib_db_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.katib_db.app_name
@@ -318,7 +318,7 @@ resource "juju_integration" "katib_db_opentelemetry_collector_k8s_grafana_loggin
 
 resource "juju_integration" "katib_db_manager_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.katib_db_manager.app_name
@@ -333,7 +333,7 @@ resource "juju_integration" "katib_db_manager_opentelemetry_collector_k8s_grafan
 
 resource "juju_integration" "katib_ui_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.katib_ui.app_name
@@ -348,7 +348,7 @@ resource "juju_integration" "katib_ui_opentelemetry_collector_k8s_grafana_loggin
 
 resource "juju_integration" "kfp_api_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_api.app_name
@@ -363,7 +363,7 @@ resource "juju_integration" "kfp_api_opentelemetry_collector_k8s_grafana_dashboa
 
 resource "juju_integration" "kfp_api_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_api.app_name
@@ -378,7 +378,7 @@ resource "juju_integration" "kfp_api_opentelemetry_collector_k8s_metrics_endpoin
 
 resource "juju_integration" "kfp_api_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_api.app_name
@@ -394,7 +394,7 @@ resource "juju_integration" "kfp_api_opentelemetry_collector_k8s_grafana_logging
 
 resource "juju_integration" "kfp_db_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_db.app_name
@@ -409,7 +409,7 @@ resource "juju_integration" "kfp_db_opentelemetry_collector_k8s_grafana_dashboar
 
 resource "juju_integration" "kfp_db_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_db.app_name
@@ -424,7 +424,7 @@ resource "juju_integration" "kfp_db_opentelemetry_collector_k8s_metrics_endpoint
 
 resource "juju_integration" "kfp_db_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_db.app_name
@@ -439,7 +439,7 @@ resource "juju_integration" "kfp_db_opentelemetry_collector_k8s_grafana_logging"
 
 resource "juju_integration" "kfp_metadata_writer_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_metadata_writer.app_name
@@ -454,7 +454,7 @@ resource "juju_integration" "kfp_metadata_writer_opentelemetry_collector_k8s_gra
 
 resource "juju_integration" "kfp_persistence_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_persistence.app_name
@@ -469,7 +469,7 @@ resource "juju_integration" "kfp_persistence_opentelemetry_collector_k8s_grafana
 
 resource "juju_integration" "kfp_profile_controller_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_profile_controller.app_name
@@ -484,7 +484,7 @@ resource "juju_integration" "kfp_profile_controller_opentelemetry_collector_k8s_
 
 resource "juju_integration" "kfp_schedwf_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_schedwf.app_name
@@ -499,7 +499,7 @@ resource "juju_integration" "kfp_schedwf_opentelemetry_collector_k8s_grafana_log
 
 resource "juju_integration" "kfp_ui_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_ui.app_name
@@ -514,7 +514,7 @@ resource "juju_integration" "kfp_ui_opentelemetry_collector_k8s_grafana_logging"
 
 resource "juju_integration" "kfp_viewer_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_viewer.app_name
@@ -529,7 +529,7 @@ resource "juju_integration" "kfp_viewer_opentelemetry_collector_k8s_grafana_logg
 
 resource "juju_integration" "kfp_viz_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_viz.app_name
@@ -544,7 +544,7 @@ resource "juju_integration" "kfp_viz_opentelemetry_collector_k8s_grafana_logging
 
 resource "juju_integration" "kserve_controller_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kserve_controller.app_name
@@ -559,7 +559,7 @@ resource "juju_integration" "kserve_controller_opentelemetry_collector_k8s_metri
 
 resource "juju_integration" "kserve_controller_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kserve_controller.app_name
@@ -574,7 +574,7 @@ resource "juju_integration" "kserve_controller_opentelemetry_collector_k8s_grafa
 
 resource "juju_integration" "kubeflow_dashboard_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_dashboard.app_name
@@ -589,7 +589,7 @@ resource "juju_integration" "kubeflow_dashboard_opentelemetry_collector_k8s_metr
 
 resource "juju_integration" "kubeflow_dashboard_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_dashboard.app_name
@@ -604,7 +604,7 @@ resource "juju_integration" "kubeflow_dashboard_opentelemetry_collector_k8s_graf
 
 resource "juju_integration" "kubeflow_dashboard_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_dashboard.app_name
@@ -620,7 +620,7 @@ resource "juju_integration" "kubeflow_dashboard_opentelemetry_collector_k8s_graf
 
 resource "juju_integration" "kubeflow_profiles_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_profiles.app_name
@@ -635,7 +635,7 @@ resource "juju_integration" "kubeflow_profiles_opentelemetry_collector_k8s_metri
 
 resource "juju_integration" "kubeflow_profiles_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_profiles.app_name
@@ -650,7 +650,7 @@ resource "juju_integration" "kubeflow_profiles_opentelemetry_collector_k8s_grafa
 
 resource "juju_integration" "kubeflow_trainer_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration && var.kubeflow_trainer_v2 ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_trainer[0].app_name
@@ -665,7 +665,7 @@ resource "juju_integration" "kubeflow_trainer_opentelemetry_collector_k8s_grafan
 
 resource "juju_integration" "kubeflow_trainer_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration && var.kubeflow_trainer_v2 ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_trainer[0].app_name
@@ -681,7 +681,7 @@ resource "juju_integration" "kubeflow_trainer_opentelemetry_collector_k8s_metric
 
 resource "juju_integration" "kubeflow_volumes_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_volumes.app_name
@@ -696,7 +696,7 @@ resource "juju_integration" "kubeflow_volumes_opentelemetry_collector_k8s_grafan
 
 resource "juju_integration" "metacontroller_operator_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.metacontroller_operator.app_name
@@ -711,7 +711,7 @@ resource "juju_integration" "metacontroller_operator_opentelemetry_collector_k8s
 
 resource "juju_integration" "metacontroller_operator_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.metacontroller_operator.app_name
@@ -726,7 +726,7 @@ resource "juju_integration" "metacontroller_operator_opentelemetry_collector_k8s
 
 resource "juju_integration" "mlmd_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.mlmd.app_name
@@ -741,7 +741,7 @@ resource "juju_integration" "mlmd_opentelemetry_collector_k8s_grafana_logging" {
 
 resource "juju_integration" "minio_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.minio.app_name
@@ -756,7 +756,7 @@ resource "juju_integration" "minio_opentelemetry_collector_k8s_grafana_dashboard
 
 resource "juju_integration" "minio_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.minio.app_name
@@ -771,7 +771,7 @@ resource "juju_integration" "minio_opentelemetry_collector_k8s_metrics_endpoint"
 
 resource "juju_integration" "oidc_gatekeeper_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.oidc_gatekeeper.app_name
@@ -786,7 +786,7 @@ resource "juju_integration" "oidc_gatekeeper_opentelemetry_collector_k8s_grafana
 
 resource "juju_integration" "pvcviewer_operator_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.pvcviewer_operator.app_name
@@ -801,7 +801,7 @@ resource "juju_integration" "pvcviewer_operator_opentelemetry_collector_k8s_graf
 
 resource "juju_integration" "pvcviewer_operator_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.pvcviewer_operator.app_name
@@ -816,7 +816,7 @@ resource "juju_integration" "pvcviewer_operator_opentelemetry_collector_k8s_metr
 
 resource "juju_integration" "pvcviewer_operator_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.pvcviewer_operator.app_name
@@ -831,7 +831,7 @@ resource "juju_integration" "pvcviewer_operator_opentelemetry_collector_k8s_graf
 
 resource "juju_integration" "tensorboard_controller_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.tensorboard_controller.app_name
@@ -846,7 +846,7 @@ resource "juju_integration" "tensorboard_controller_opentelemetry_collector_k8s_
 
 resource "juju_integration" "tensorboard_controller_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.tensorboard_controller.app_name
@@ -861,7 +861,7 @@ resource "juju_integration" "tensorboard_controller_opentelemetry_collector_k8s_
 
 resource "juju_integration" "tensorboards_web_app_opentelemetry_collector_k8s_grafana_logging" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.tensorboards_web_app.app_name
@@ -876,7 +876,7 @@ resource "juju_integration" "tensorboards_web_app_opentelemetry_collector_k8s_gr
 
 resource "juju_integration" "training_operator_opentelemetry_collector_k8s_grafana_dashboard" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.training_operator.app_name
@@ -891,7 +891,7 @@ resource "juju_integration" "training_operator_opentelemetry_collector_k8s_grafa
 
 resource "juju_integration" "training_operator_opentelemetry_collector_k8s_metrics_endpoint" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.training_operator.app_name
@@ -906,7 +906,7 @@ resource "juju_integration" "training_operator_opentelemetry_collector_k8s_metri
 
 resource "juju_integration" "istio_beacon_k8s_opentelemetry_collector_k8s_service_mesh" {
   count = var.cos_configuration ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name

--- a/modules/kubeflow-ambient/integrations.tf
+++ b/modules/kubeflow-ambient/integrations.tf
@@ -1,6 +1,6 @@
 
 resource "juju_integration" "argo_controller_minio" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.argo_controller.app_name
@@ -14,7 +14,7 @@ resource "juju_integration" "argo_controller_minio" {
 }
 
 resource "juju_integration" "dex_auth_oidc_gatekeeper_dex_oidc_config" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.dex_auth.app_name
@@ -28,7 +28,7 @@ resource "juju_integration" "dex_auth_oidc_gatekeeper_dex_oidc_config" {
 }
 
 resource "juju_integration" "dex_auth_oidc_gatekeeper_oidc_client" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.dex_auth.app_name
@@ -42,7 +42,7 @@ resource "juju_integration" "dex_auth_oidc_gatekeeper_oidc_client" {
 }
 
 resource "juju_integration" "katib_db_manager_katib_controller_k8s_service_info" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.katib_db_manager.app_name
@@ -56,7 +56,7 @@ resource "juju_integration" "katib_db_manager_katib_controller_k8s_service_info"
 }
 
 resource "juju_integration" "katib_db_manager_katib_db_relational_db" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.katib_db_manager.app_name
@@ -70,7 +70,7 @@ resource "juju_integration" "katib_db_manager_katib_db_relational_db" {
 }
 
 resource "juju_integration" "kfp_api_kfp_db_database" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_api.app_name
@@ -84,7 +84,7 @@ resource "juju_integration" "kfp_api_kfp_db_database" {
 }
 
 resource "juju_integration" "kfp_api_kfp_persistence_database" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_api.app_name
@@ -98,7 +98,7 @@ resource "juju_integration" "kfp_api_kfp_persistence_database" {
 }
 
 resource "juju_integration" "kfp_api_kfp_ui_database" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_api.app_name
@@ -112,7 +112,7 @@ resource "juju_integration" "kfp_api_kfp_ui_database" {
 }
 
 resource "juju_integration" "kfp_api_kfp_viz_database" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_api.app_name
@@ -126,7 +126,7 @@ resource "juju_integration" "kfp_api_kfp_viz_database" {
 }
 
 resource "juju_integration" "kfp_api_minio_object_storage" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_api.app_name
@@ -140,7 +140,7 @@ resource "juju_integration" "kfp_api_minio_object_storage" {
 }
 
 resource "juju_integration" "kfp_profile_controller_minio_object_storage" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_profile_controller.app_name
@@ -154,7 +154,7 @@ resource "juju_integration" "kfp_profile_controller_minio_object_storage" {
 }
 
 resource "juju_integration" "kfp_ui_minio_object_storage" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_ui.app_name
@@ -168,7 +168,7 @@ resource "juju_integration" "kfp_ui_minio_object_storage" {
 }
 
 resource "juju_integration" "kubeflow_profiles_kubeflow_dashboard_kubeflow_profiles" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_profiles.app_name
@@ -182,7 +182,7 @@ resource "juju_integration" "kubeflow_profiles_kubeflow_dashboard_kubeflow_profi
 }
 
 resource "juju_integration" "kubeflow_dashboard_jupyter_ui_links" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_dashboard.app_name
@@ -196,7 +196,7 @@ resource "juju_integration" "kubeflow_dashboard_jupyter_ui_links" {
 }
 
 resource "juju_integration" "kubeflow_dashboard_katib_ui_links" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_dashboard.app_name
@@ -210,7 +210,7 @@ resource "juju_integration" "kubeflow_dashboard_katib_ui_links" {
 }
 
 resource "juju_integration" "kubeflow_dashboard_kfp_ui_links" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_dashboard.app_name
@@ -225,7 +225,7 @@ resource "juju_integration" "kubeflow_dashboard_kfp_ui_links" {
 
 resource "juju_integration" "kubeflow_dashboard_kubeflow_trainer_links" {
   count = var.kubeflow_trainer_v2 ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_dashboard.app_name
@@ -239,7 +239,7 @@ resource "juju_integration" "kubeflow_dashboard_kubeflow_trainer_links" {
 }
 
 resource "juju_integration" "kubeflow_dashboard_kubeflow_volumes_links" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_dashboard.app_name
@@ -253,7 +253,7 @@ resource "juju_integration" "kubeflow_dashboard_kubeflow_volumes_links" {
 }
 
 resource "juju_integration" "kubeflow_dashboard_tensorboards_web_app_links" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_dashboard.app_name
@@ -267,7 +267,7 @@ resource "juju_integration" "kubeflow_dashboard_tensorboards_web_app_links" {
 }
 
 resource "juju_integration" "kubeflow_dashboard_training_operator_links" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kubeflow_dashboard.app_name
@@ -281,7 +281,7 @@ resource "juju_integration" "kubeflow_dashboard_training_operator_links" {
 }
 
 resource "juju_integration" "mlmd_envoy_grpc" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.mlmd.app_name
@@ -295,7 +295,7 @@ resource "juju_integration" "mlmd_envoy_grpc" {
 }
 
 resource "juju_integration" "mlmd_kfp_metadata_writer_grpc" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.mlmd.app_name
@@ -309,7 +309,7 @@ resource "juju_integration" "mlmd_kfp_metadata_writer_grpc" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_admission_webhook" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -323,7 +323,7 @@ resource "juju_integration" "istio_beacon_k8s_admission_webhook" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_dex_auth" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -337,7 +337,7 @@ resource "juju_integration" "istio_beacon_k8s_dex_auth" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_katib_controller" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -351,7 +351,7 @@ resource "juju_integration" "istio_beacon_k8s_katib_controller" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_katib_ui" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -365,7 +365,7 @@ resource "juju_integration" "istio_beacon_k8s_katib_ui" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_kfp_api" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -379,7 +379,7 @@ resource "juju_integration" "istio_beacon_k8s_kfp_api" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_kfp_persistence" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -393,7 +393,7 @@ resource "juju_integration" "istio_beacon_k8s_kfp_persistence" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_kfp_profile_controller" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -407,7 +407,7 @@ resource "juju_integration" "istio_beacon_k8s_kfp_profile_controller" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_kfp_schedwf" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -421,7 +421,7 @@ resource "juju_integration" "istio_beacon_k8s_kfp_schedwf" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_kfp_ui" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -435,7 +435,7 @@ resource "juju_integration" "istio_beacon_k8s_kfp_ui" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_kfp_viz" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -449,7 +449,7 @@ resource "juju_integration" "istio_beacon_k8s_kfp_viz" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_kubeflow_dashboard" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -463,7 +463,7 @@ resource "juju_integration" "istio_beacon_k8s_kubeflow_dashboard" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_kubeflow_profiles" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -477,7 +477,7 @@ resource "juju_integration" "istio_beacon_k8s_kubeflow_profiles" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_kubeflow_volumes" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -491,7 +491,7 @@ resource "juju_integration" "istio_beacon_k8s_kubeflow_volumes" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_minio" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -505,7 +505,7 @@ resource "juju_integration" "istio_beacon_k8s_minio" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_oidc_gatekeeper" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -519,7 +519,7 @@ resource "juju_integration" "istio_beacon_k8s_oidc_gatekeeper" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_pvcviewer_operator" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -533,7 +533,7 @@ resource "juju_integration" "istio_beacon_k8s_pvcviewer_operator" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_tensorboard_controller" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -547,7 +547,7 @@ resource "juju_integration" "istio_beacon_k8s_tensorboard_controller" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_tensorboards_web_app" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -561,7 +561,7 @@ resource "juju_integration" "istio_beacon_k8s_tensorboards_web_app" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_jupyter_controller" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -575,7 +575,7 @@ resource "juju_integration" "istio_beacon_k8s_jupyter_controller" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_jupyter_ui" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -589,7 +589,7 @@ resource "juju_integration" "istio_beacon_k8s_jupyter_ui" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_envoy" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -603,7 +603,7 @@ resource "juju_integration" "istio_beacon_k8s_envoy" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_kserve_controller" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -617,7 +617,7 @@ resource "juju_integration" "istio_beacon_k8s_kserve_controller" {
 }
 
 resource "juju_integration" "istio_ingress_k8s_kubeflow_volumes" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_ingress_k8s.name
@@ -631,7 +631,7 @@ resource "juju_integration" "istio_ingress_k8s_kubeflow_volumes" {
 }
 
 resource "juju_integration" "istio_ingress_k8s_kfp_ui" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_ingress_k8s.name
@@ -645,7 +645,7 @@ resource "juju_integration" "istio_ingress_k8s_kfp_ui" {
 }
 
 resource "juju_integration" "istio_ingress_k8s_envoy" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_ingress_k8s.name
@@ -659,7 +659,7 @@ resource "juju_integration" "istio_ingress_k8s_envoy" {
 }
 
 resource "juju_integration" "istio_ingress_k8s_katib_ui" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_ingress_k8s.name
@@ -673,7 +673,7 @@ resource "juju_integration" "istio_ingress_k8s_katib_ui" {
 }
 
 resource "juju_integration" "istio_ingress_k8s_kubeflow_dashboard" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_ingress_k8s.name
@@ -687,7 +687,7 @@ resource "juju_integration" "istio_ingress_k8s_kubeflow_dashboard" {
 }
 
 resource "juju_integration" "istio_ingress_k8s_jupyter_ui" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_ingress_k8s.name
@@ -701,7 +701,7 @@ resource "juju_integration" "istio_ingress_k8s_jupyter_ui" {
 }
 
 resource "juju_integration" "istio_ingress_k8s_tensorboards_web_app" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_ingress_k8s.name
@@ -715,7 +715,7 @@ resource "juju_integration" "istio_ingress_k8s_tensorboards_web_app" {
 }
 
 resource "juju_integration" "oidc_gatekeeper_istio_ingress_k8s_unauthenticated" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.oidc_gatekeeper.app_name
@@ -729,7 +729,7 @@ resource "juju_integration" "oidc_gatekeeper_istio_ingress_k8s_unauthenticated" 
 }
 
 resource "juju_integration" "oidc_gatekeeper_istio_ingress_k8s_forward_auth" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.oidc_gatekeeper.app_name
@@ -743,7 +743,7 @@ resource "juju_integration" "oidc_gatekeeper_istio_ingress_k8s_forward_auth" {
 }
 
 resource "juju_integration" "dex_auth_istio_ingress_k8s_unauthenticated" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.dex_auth.app_name
@@ -757,7 +757,7 @@ resource "juju_integration" "dex_auth_istio_ingress_k8s_unauthenticated" {
 }
 
 resource "juju_integration" "istio_k8s_istio_ingress_k8s_ingress_config" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.istio[0].name : local.istio_system_model
 
   application {
     name     = juju_application.istio_k8s.name
@@ -765,13 +765,12 @@ resource "juju_integration" "istio_k8s_istio_ingress_k8s_ingress_config" {
   }
 
   application {
-    name     = juju_application.istio_ingress_k8s.name
-    endpoint = "istio-ingress-config"
+    offer_url = juju_offer.istio_ingress_k8s_ingress_config.url
   }
 }
 
 resource "juju_integration" "jupyter_controller_istio_ingress_k8s_gateway_metadata" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.jupyter_controller.app_name
@@ -785,7 +784,7 @@ resource "juju_integration" "jupyter_controller_istio_ingress_k8s_gateway_metada
 }
 
 resource "juju_integration" "pvcviewer_operator_istio_ingress_k8s_gateway_metadata" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.pvcviewer_operator.app_name
@@ -799,7 +798,7 @@ resource "juju_integration" "pvcviewer_operator_istio_ingress_k8s_gateway_metada
 }
 
 resource "juju_integration" "tensorboard_controller_istio_ingress_k8s_gateway_metadata" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.tensorboard_controller.app_name
@@ -813,7 +812,7 @@ resource "juju_integration" "tensorboard_controller_istio_ingress_k8s_gateway_me
 }
 
 resource "juju_integration" "kserve_controller_istio_ingress_k8s_gateway_metadata" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kserve_controller.app_name
@@ -827,7 +826,7 @@ resource "juju_integration" "kserve_controller_istio_ingress_k8s_gateway_metadat
 }
 
 resource "juju_integration" "kfp_api_kfp_persistence_grpc" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_api.app_name
@@ -841,7 +840,7 @@ resource "juju_integration" "kfp_api_kfp_persistence_grpc" {
 }
 
 resource "juju_integration" "istio_beacon_k8s_training_operator" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -856,7 +855,7 @@ resource "juju_integration" "istio_beacon_k8s_training_operator" {
 
 resource "juju_integration" "istio_beacon_k8s_kubeflow_trainer" {
   count = var.kubeflow_trainer_v2 ? 1 : 0
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = juju_application.istio_beacon_k8s.name
@@ -870,7 +869,7 @@ resource "juju_integration" "istio_beacon_k8s_kubeflow_trainer" {
 }
 
 resource "juju_integration" "kfp_api_kfp_schedwf_grpc" {
-  model = var.create_model ? juju_model.kubeflow[0].name : local.model
+  model = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
 
   application {
     name     = module.kfp_api.app_name

--- a/modules/kubeflow-ambient/main.tf
+++ b/modules/kubeflow-ambient/main.tf
@@ -1,6 +1,17 @@
+resource "juju_model" "istio" {
+  count = var.create_model ? 1 : 0
+  name  = local.kubeflow_platform_model
+
+  config = {
+    juju-http-proxy  = var.http_proxy
+    juju-https-proxy = var.https_proxy
+    juju-no-proxy    = var.no_proxy
+  }
+}
+
 resource "juju_model" "kubeflow" {
   count = var.create_model ? 1 : 0
-  name  = local.model
+  name  = local.istio_system_model
 
   config = {
     juju-http-proxy  = var.http_proxy
@@ -10,5 +21,6 @@ resource "juju_model" "kubeflow" {
 }
 
 locals {
-  model = "kubeflow"
+  istio_system_model = "istio-system"
+  kubeflow_platform_model = "kubeflow"
 }

--- a/modules/kubeflow-ambient/offers.tf
+++ b/modules/kubeflow-ambient/offers.tf
@@ -1,0 +1,5 @@
+resource "juju_offer" "istio_ingress_k8s_ingress_config" {
+  model            = var.create_model ? juju_model.kubeflow[0].name : local.kubeflow_platform_model
+  application_name = juju_application.istio_ingress_k8s.name
+  endpoints        = ["istio-ingress-config"]
+}

--- a/modules/kubeflow-ambient/outputs.tf
+++ b/modules/kubeflow-ambient/outputs.tf
@@ -27,6 +27,6 @@ output "kserve_controller" {
 }
 
 output "model" {
-  value = var.create_model ? one(juju_model.kubeflow[*].name) : local.model
+  value = var.create_model ? one(juju_model.kubeflow[*].name) : local.kubeflow_platform_model
 }
 

--- a/modules/kubeflow-ambient/tests/conftest.py
+++ b/modules/kubeflow-ambient/tests/conftest.py
@@ -16,8 +16,8 @@ def juju(request: pytest.FixtureRequest):
             print(log, end="")
 
     juju_instance = jubilant.Juju()
-    juju_instance.add_model(MODEL_NAME_FOR_ISTIO_SYSTEM)
-    juju_instance.add_model(MODEL_NAME_FOR_KUBEFLOW_PLATFORM)
+    # juju_instance.add_model(MODEL_NAME_FOR_ISTIO_SYSTEM)
+    # juju_instance.add_model(MODEL_NAME_FOR_KUBEFLOW_PLATFORM)
 
     try:
         yield juju_instance

--- a/modules/kubeflow-ambient/tests/conftest.py
+++ b/modules/kubeflow-ambient/tests/conftest.py
@@ -3,7 +3,8 @@
 import jubilant
 import pytest
 
-MODEL_NAME = "kubeflow"
+MODEL_NAME_FOR_ISTIO_SYSTEM = "istio-system"
+MODEL_NAME_FOR_KUBEFLOW_PLATFORM = "kubeflow"
 
 @pytest.fixture(scope="module")
 def juju(request: pytest.FixtureRequest):
@@ -15,7 +16,8 @@ def juju(request: pytest.FixtureRequest):
             print(log, end="")
 
     juju_instance = jubilant.Juju()
-    juju_instance.add_model(MODEL_NAME)
+    juju_instance.add_model(MODEL_NAME_FOR_ISTIO_SYSTEM)
+    juju_instance.add_model(MODEL_NAME_FOR_KUBEFLOW_PLATFORM)
 
     try:
         yield juju_instance


### PR DESCRIPTION
This pull request does the same as https://github.com/canonical/charmed-kubeflow-solutions/pull/118 after moving Istio, now in ambient mode, to a separate namespace (so that its CNI does not prevent PSS from being applied to the Kubeflow-platform namespace).

**note: do not merge as these changes are just for temporary testing**