### PR TITLE
[KF-8177] Use track 1.10/ for minio (#92)

### DIFF
--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -75,7 +75,7 @@ jobs:
         run: |
           # Avoiding dockerhub rate limits (see https://canonical-self-hosted-github-runner-docs.readthedocs-hosted.com/en/latest/usage/faq/how-to-avoid-dockerhub-rate-limits/ for more informations)
           if [ -n "$DOCKERHUB_MIRROR" ]; then
-          MIRROR_CONFIG=/opt/containerd/k8s-containerd/etc/containerd/hosts.d/docker.io
+          MIRROR_CONFIG=/etc/containerd/hosts.d/docker.io
             
           sudo mkdir -p ${MIRROR_CONFIG}
           sudo chown $USER ${MIRROR_CONFIG}

--- a/.github/workflows/deploy-to-microk8s.yaml
+++ b/.github/workflows/deploy-to-microk8s.yaml
@@ -80,7 +80,7 @@ jobs:
           channel: ${{ format('{0}-strict/stable', env.K8S_VERSION) }}
           microk8s-group: snap_microk8s
           microk8s-addons: "rbac dns hostpath-storage metallb:10.64.140.43-10.64.140.49"
-          bootstrap-options: "--agent-version 3.6.9"
+          bootstrap-options: "--agent-version 3.6.19"
 
       - name: Setup terraform
         run: |          

--- a/modules/kubeflow-feast/applications.tf
+++ b/modules/kubeflow-feast/applications.tf
@@ -16,7 +16,7 @@ module "feast_ui" {
 
 module "feast_offline_store" {
   # tflint-ignore: terraform_module_pinned_source
-  source          = "git::https://github.com/canonical/postgresql-k8s-operator//terraform?ref=main"
+  source          = "git::https://github.com/canonical/postgresql-k8s-operator//terraform?ref=ac1f27eae4d9ccee2557ec84a175fbb5722e45be"
   juju_model_name = module.kubeflow.model
   app_name        = "feast-offline-store"
   channel         = "14/stable"
@@ -30,7 +30,7 @@ module "feast_offline_store" {
 
 module "feast_online_store" {
   # tflint-ignore: terraform_module_pinned_source
-  source          = "git::https://github.com/canonical/postgresql-k8s-operator//terraform?ref=main"
+  source          = "git::https://github.com/canonical/postgresql-k8s-operator//terraform?ref=ac1f27eae4d9ccee2557ec84a175fbb5722e45be"
   juju_model_name = module.kubeflow.model
   app_name        = "feast-online-store"
   channel         = "14/stable"
@@ -44,7 +44,7 @@ module "feast_online_store" {
 
 module "feast_registry" {
   # tflint-ignore: terraform_module_pinned_source
-  source          = "git::https://github.com/canonical/postgresql-k8s-operator//terraform?ref=main"
+  source          = "git::https://github.com/canonical/postgresql-k8s-operator//terraform?ref=ac1f27eae4d9ccee2557ec84a175fbb5722e45be"
   juju_model_name = module.kubeflow.model
   app_name        = "feast-registry"
   channel         = "14/stable"

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -276,7 +276,7 @@ module "mlmd" {
 }
 
 module "minio" {
-  source     = "git::https://github.com/canonical/minio-operator//terraform?ref=a778843730a3966690aa2042ff031f862b14d5ec"
+  source     = "git::https://github.com/canonical/minio-operator//terraform?ref=d72b4090c0928d3480da87cefd6799c7b13dc45e"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   config = {
     access-key               = var.minio_access_key,
@@ -289,7 +289,7 @@ module "minio" {
     minio-data = var.minio_size
   }
   revision = var.minio_revision
-  channel  = "ckf-1.10/${var.risk}"
+  channel  = "1.10/${var.risk}"
 }
 
 module "oidc_gatekeeper" {


### PR DESCRIPTION
backporting #92 

To allow the CI to pass, it is also required to:
* pin postgresql to use TF modules < 1.0.0 (that has been part of #102 )
* update juju version since latest juju snap does not allow to bootstrap agent version prior of 3.6.18