### PR TITLE
[KF-8177] pinning new mlflow terraform module

### DIFF
--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -69,7 +69,7 @@ module "kubeflow" {
 }
 
 module "mlflow" {
-  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=2b1afe5348aa4f3f552414bec73959aca6da8bc9"
+  source = "git::https://github.com/canonical/charmed-mlflow-solutions//modules/mlflow?ref=3dafc7d53ecad47adaa3836dc74665ecacba1759"
   # kubeflow module creates the model
   risk                                  = var.risk
   create_model                          = false


### PR DESCRIPTION
Previous edit didn't pin the mlflow module that would now refer to minio from the `1.10/` track