### PR TITLE
[KF-7559] Enable Running Kubeflow behind proxy (PS7)

### DIFF
--- a/modules/kubeflow-ambient/main.tf
+++ b/modules/kubeflow-ambient/main.tf
@@ -10,6 +10,6 @@ resource "juju_model" "kubeflow" {
 }
 
 locals {
-  model                 = "kubeflow"
-  channel_latest_edge   = "latest/edge"
+  model               = "kubeflow"
+  channel_latest_edge = "latest/edge"
 }

--- a/modules/kubeflow/main.tf
+++ b/modules/kubeflow/main.tf
@@ -1,6 +1,12 @@
 resource "juju_model" "kubeflow" {
   count = var.create_model ? 1 : 0
   name  = local.model
+
+  config = {
+    juju-http-proxy = var.http_proxy
+    juju-https-proxy = var.https_proxy
+    juju-no-proxy = var.no_proxy
+  }
 }
 
 locals {

--- a/modules/kubeflow/main.tf
+++ b/modules/kubeflow/main.tf
@@ -3,9 +3,9 @@ resource "juju_model" "kubeflow" {
   name  = local.model
 
   config = {
-    juju-http-proxy = var.http_proxy
+    juju-http-proxy  = var.http_proxy
     juju-https-proxy = var.https_proxy
-    juju-no-proxy = var.no_proxy
+    juju-no-proxy    = var.no_proxy
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/canonical/charmed-kubeflow-solutions/issues/50

The PR backport changes that already landed on 1.10 on https://github.com/canonical/charmed-kubeflow-solutions/pull/102 that are required to make Kubeflow seamlessly work in an environment behind proxy. 

The deployment was validated using a modified versions of the UATs to make them work on environment behind proxies, PR: https://github.com/canonical/charmed-kubeflow-uats/pull/262 

## To Reproduce on PS7

1. Extract env variables

```
export HTTP_PROXY=http://egress.ps7.internal:3128
export HTTPS_PROXY=http://egress.ps7.internal:3128
export CLUSTER_CIDR=$(cat /var/snap/microk8s/current/args/kube-proxy | grep cluster-cidr | sed 's/^[^=]*=//')
export SERVICE_CLUSTER_IP_RANGE=$(cat /var/snap/microk8s/current/args/kube-apiserver | grep service-cluster-ip-range | sed 's/^[^=]*=//')
export NODE_INTERNAL_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
export HOSTNAME=$(hostname)
export NO_PROXY="$CLUSTER_CIDR,$SERVICE_CLUSTER_IP_RANGE,127.0.0.1,localhost,$NODE_INTERNAL_IP/24,$HOSTNAME,.svc,.local,.kubeflow"
```

2. Setup MicroK8s normally

```
sudo snap install microk8s --channel 1.32-strict/stable
sudo microk8s enable hostpath-storage dns rbac storage       
sudo snap alias microk8s.kubectl kubectl 
microk8s config > ~/.kube/config
IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc') 
sudo microk8s enable metallb:$IPADDR-$IPADDR
microk8s kubectl rollout status deployments/hostpath-provisioner -n kube-system -w
microk8s kubectl rollout status deployments/coredns -n kube-system -w
microk8s kubectl rollout status daemonset.apps/speaker -n metallb-system -w
```

3. Bootstrap Juju, and setting proxy for controller model

```
juju bootstrap microk8s micro
juju switch controller

juju model-config no-proxy="${NO_PROXY}"
juju model-config http-proxy="${HTTP_PROXY}"
juju model-config https-proxy="${HTTPS_PROXY}"
```

4. Deploy Kubeflow 
  * create tfvars.json

```
{
    "kubeflow_trainer_v2": true,
    "dex_static_username": "admin",
    "dex_static_password": "admin",
    "http_proxy": "http://egress.ps7.internal:3128",
    "https_proxy": "http://egress.ps7.internal:3128",
    "no_proxy": "10.0.0.0/8,10.152.183.0/24,10.152.183.1,127.0.0.1,localhost,10.151.42.84/24,juju-e91d1b-stg-kubeflow-ps7-testing-57,.svc,.local,.kubeflow"
}
```

  * and then apply

```
terraform init

terraform apply -var-file tfvars.json -auto-approve
```

5. Run the uats

```
tox -e kubeflow-mlflow-local -- --proxy http_proxy=$HTTP_PROXY https_proxy=$HTTPS_PROXY no_proxy=$NO_PROXY >uats.out 2>uats.err
```