### PR TITLE
feat: add Notebooks component

### DIFF
--- a/scripts/tox.ini
+++ b/scripts/tox.ini
@@ -3,8 +3,8 @@
 
 [tox]
 envlist = 
-    lint-{auth,core,istio-ambient,istio-sidecar,katib,kfp,kubeflow,minio,tensorboard}
-    validate-{auth,core,istio-ambient,istio-sidecar,katib,kfp,kubeflow,minio,tensorboard}
+    lint-{auth,core,istio-ambient,istio-sidecar,katib,kfp,kubeflow,minio,notebooks,tensorboard}
+    validate-{auth,core,istio-ambient,istio-sidecar,katib,kfp,kubeflow,minio,notebooks,tensorboard}
 
 [vars]
 tf_modules_path = {tox_root}/../terraform-refactoring/
@@ -24,6 +24,7 @@ set_env =
     kfp: TYPE=components
     kubeflow: TYPE=products
     minio: TYPE=charms
+    notebooks: TYPE=components
     tensorboard: TYPE=components
     # set module name
     auth: MODULE=auth
@@ -34,15 +35,16 @@ set_env =
     kfp: MODULE=kfp
     kubeflow: MODULE=kubeflow
     minio: MODULE=minio
+    notebooks: MODULE=notebooks
     tensorboard: MODULE=tensorboard
 
-[testenv:lint-{auth,core,istio-ambient,istio-sidecar,katib,kubeflow,minio,tensorboard}]
+[testenv:lint-{auth,core,istio-ambient,istio-sidecar,katib,kubeflow,minio,notebooks,tensorboard}]
 description = Check Terraform code against coding style standards
 commands =
     terraform -chdir={[vars]tf_modules_path}{env:TYPE}/{env:MODULE} fmt -recursive -check -diff
     tflint --recursive --chdir={[vars]tf_modules_path}{env:TYPE}/{env:MODULE}
 
-[testenv:validate-{auth,core,istio-ambient,istio-sidecar,katib,kfp,kubeflow,minio,tensorboard}]
+[testenv:validate-{auth,core,istio-ambient,istio-sidecar,katib,kfp,kubeflow,minio,notebooks,tensorboard}]
 description = Apply coding style standards to code
 commands =
     terraform -chdir={[vars]tf_modules_path}{env:TYPE}/{env:MODULE} init

--- a/terraform-refactoring/components/core/README.md
+++ b/terraform-refactoring/components/core/README.md
@@ -20,12 +20,14 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
+| [juju_application.admission_webhook](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_application.kubeflow_dashboard](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_application.kubeflow_profiles](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_application.kubeflow_roles](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_application.kubeflow_volumes](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_application.metacontroller_operator](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
 | [juju_application.pvcviewer_operator](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+| [juju_integration.admission_webhook_service_mesh](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
 | [juju_integration.kubeflow_dashboard_ingress](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
 | [juju_integration.kubeflow_dashboard_istio_ingress_route](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
 | [juju_integration.kubeflow_dashboard_service_mesh](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
@@ -42,6 +44,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_admission_webhook"></a> [admission\_webhook](#input\_admission\_webhook) | Configuration for admission-webhook application | <pre>object({<br/>    channel     = optional(string, "1.10/stable")<br/>    revision    = optional(number)<br/>    units       = optional(number, 1)<br/>    trust       = optional(bool, true)<br/>    constraints = optional(string)<br/>    config      = optional(map(string), {})<br/>    resources   = optional(map(string), {})<br/>  })</pre> | `{}` | no |
 | <a name="input_gateway_metadata"></a> [gateway\_metadata](#input\_gateway\_metadata) | Gateway metadata provider for pvcviewer-operator from istio-ingress-k8s:gateway-metadata (supports same-model endpoint or cross-model offer) | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | `null` | no |
 | <a name="input_ingress"></a> [ingress](#input\_ingress) | Ingress provider for core applications (supports same-model endpoint or cross-model offer) | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | `null` | no |
 | <a name="input_istio_ingress_route"></a> [istio\_ingress\_route](#input\_istio\_ingress\_route) | Istio ingress route provider for core applications from istio-ingress-k8s:istio-ingress-route (supports same-model endpoint or cross-model offer) | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | `null` | no |

--- a/terraform-refactoring/components/core/applications.tf
+++ b/terraform-refactoring/components/core/applications.tf
@@ -1,6 +1,23 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+# Admission Webhook application
+resource "juju_application" "admission_webhook" {
+  charm {
+    name     = "admission-webhook"
+    channel  = var.admission_webhook.channel
+    revision = var.admission_webhook.revision
+  }
+
+  model_uuid  = var.model_uuid
+  name        = "admission-webhook"
+  units       = var.admission_webhook.units
+  trust       = var.admission_webhook.trust
+  constraints = var.admission_webhook.constraints
+  config      = var.admission_webhook.config
+  resources   = var.admission_webhook.resources
+}
+
 # Kubeflow Dashboard application
 resource "juju_application" "kubeflow_dashboard" {
   charm {

--- a/terraform-refactoring/components/core/integrations.tf
+++ b/terraform-refactoring/components/core/integrations.tf
@@ -135,6 +135,22 @@ resource "juju_integration" "pvcviewer_operator_service_mesh" {
   }
 }
 
+resource "juju_integration" "admission_webhook_service_mesh" {
+  count      = var.service_mesh != null ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.admission_webhook.name
+    endpoint = "service-mesh"
+  }
+
+  application {
+    name      = var.service_mesh.kind == "endpoint" ? var.service_mesh.name : null
+    endpoint  = var.service_mesh.kind == "endpoint" ? var.service_mesh.endpoint : null
+    offer_url = var.service_mesh.kind == "offer" ? var.service_mesh.url : null
+  }
+}
+
 resource "juju_integration" "pvcviewer_operator_gateway_metadata" {
   count      = var.gateway_metadata != null ? 1 : 0
   model_uuid = var.model_uuid

--- a/terraform-refactoring/components/core/outputs.tf
+++ b/terraform-refactoring/components/core/outputs.tf
@@ -4,6 +4,7 @@
 output "components" {
   description = "Map of the deployed core component applications"
   value = {
+    admission_webhook  = juju_application.admission_webhook
     kubeflow_dashboard = juju_application.kubeflow_dashboard
     kubeflow_profiles  = juju_application.kubeflow_profiles
     kubeflow_roles     = juju_application.kubeflow_roles
@@ -60,6 +61,10 @@ output "requires" {
     pvcviewer_operator_gateway_metadata = {
       name     = juju_application.pvcviewer_operator.name
       endpoint = "gateway-metadata"
+    }
+    admission_webhook_service_mesh = {
+      name     = juju_application.admission_webhook.name
+      endpoint = "service-mesh"
     }
   }
 }

--- a/terraform-refactoring/components/core/variables.tf
+++ b/terraform-refactoring/components/core/variables.tf
@@ -1,6 +1,20 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+variable "admission_webhook" {
+  description = "Configuration for admission-webhook application"
+  type = object({
+    channel     = optional(string, "1.10/stable")
+    revision    = optional(number)
+    units       = optional(number, 1)
+    trust       = optional(bool, true)
+    constraints = optional(string)
+    config      = optional(map(string), {})
+    resources   = optional(map(string), {})
+  })
+  default = {}
+}
+
 variable "model_uuid" {
   description = "UUID of the Juju model where core components are deployed"
   type        = string

--- a/terraform-refactoring/components/notebooks/README.md
+++ b/terraform-refactoring/components/notebooks/README.md
@@ -1,0 +1,81 @@
+# Notebooks Component
+
+Terraform module deploying the Notebooks component for Charmed Kubeflow.
+
+## Applications
+
+| Name | Charm | Description |
+| ---- | ----- | ----------- |
+| notebook-controller | notebook-controller | Notebook CRD controller |
+| notebook-web-app | notebook-web-app | Notebook web UI |
+
+## Inputs
+
+| Name | Description | Required |
+| ---- | ----------- | :------: |
+| `model_uuid` | UUID of the Juju model | yes |
+| `dashboard_links` | Kubeflow Dashboard links provider for notebook-web-app | no |
+| `ingress` | Ingress provider for notebook-web-app (istio sidecar) | no |
+| `istio_ingress_route` | Istio ingress route for notebook-web-app (ambient) | no |
+| `service_mesh` | Service mesh provider for all Notebooks apps (ambient) | no |
+| `notebook_controller` | Configuration for notebook-controller | no |
+| `notebook_web_app` | Configuration for notebook-web-app | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| `components` | Map of deployed Notebooks applications |
+| `requires` | Endpoints required from other components |
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 1.1.1 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.1.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [juju_application.jupyter_controller](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+| [juju_application.jupyter_ui](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application) | resource |
+| [juju_integration.jupyter-controller_service_mesh](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.jupyter_controller_gateway_metadata](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.jupyter_ui_dashboard_links](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.jupyter_ui_ingress](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.jupyter_ui_service_mesh](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+| [juju_integration.notebook_web_app_istio_ingress_route](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/integration) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_dashboard_links"></a> [dashboard\_links](#input\_dashboard\_links) | Kubeflow Dashboard links provider for jupyter-ui from kubeflow-dashboard:links (supports same-model endpoint or cross-model offer) | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | `null` | no |
+| <a name="input_gateway_metadata"></a> [gateway\_metadata](#input\_gateway\_metadata) | Gateway metadata provider for jupyter-controller from istio-ingress-k8s:gateway-metadata (supports same-model endpoint or cross-model offer) | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | `null` | no |
+| <a name="input_ingress"></a> [ingress](#input\_ingress) | Ingress provider for notebook-web-app from istio-pilot:ingress (supports same-model endpoint or cross-model offer) | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | `null` | no |
+| <a name="input_istio_ingress_route"></a> [istio\_ingress\_route](#input\_istio\_ingress\_route) | Istio ingress route provider for notebook-web-app from istio-ingress-k8s:istio-ingress-route (supports same-model endpoint or cross-model offer) | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | `null` | no |
+| <a name="input_jupyter_controller"></a> [jupyter\_controller](#input\_jupyter\_controller) | Configuration for jupyter-controller application | <pre>object({<br/>    app_name    = optional(string, "jupyter-controller")<br/>    channel     = optional(string, "1.10/stable")<br/>    revision    = optional(number)<br/>    units       = optional(number, 1)<br/>    trust       = optional(bool, true)<br/>    constraints = optional(string, "arch=amd64")<br/>    config      = optional(map(string), {})<br/>    resources   = optional(map(string), {})<br/>  })</pre> | `{}` | no |
+| <a name="input_jupyter_ui"></a> [jupyter\_ui](#input\_jupyter\_ui) | Configuration for jupyter-ui application | <pre>object({<br/>    app_name    = optional(string, "jupyter-ui")<br/>    channel     = optional(string, "1.10/stable")<br/>    revision    = optional(number)<br/>    units       = optional(number, 1)<br/>    trust       = optional(bool, true)<br/>    constraints = optional(string, "arch=amd64")<br/>    config      = optional(map(string), {})<br/>    resources   = optional(map(string), {})<br/>  })</pre> | `{}` | no |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | UUID of the Juju model where Notebooks is deployed | `string` | n/a | yes |
+| <a name="input_service_mesh"></a> [service\_mesh](#input\_service\_mesh) | Service mesh provider for Notebooks applications from istio-beacon-k8s:service-mesh (supports same-model endpoint or cross-model offer) | <pre>object({<br/>    kind     = string<br/>    name     = optional(string, null)<br/>    endpoint = optional(string, null)<br/>    url      = optional(string, null)<br/>  })</pre> | `null` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_components"></a> [components](#output\_components) | Map of the deployed Notebooks applications |
+| <a name="output_requires"></a> [requires](#output\_requires) | Map of endpoints required by this component from other components (inbound relations) |
+<!-- END_TF_DOCS -->

--- a/terraform-refactoring/components/notebooks/applications.tf
+++ b/terraform-refactoring/components/notebooks/applications.tf
@@ -1,0 +1,36 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Notebook Controller application
+resource "juju_application" "jupyter_controller" {
+  charm {
+    name     = "jupyter-controller"
+    channel  = var.jupyter_controller.channel
+    revision = var.jupyter_controller.revision
+  }
+
+  model_uuid  = var.model_uuid
+  name        = var.jupyter_controller.app_name
+  units       = var.jupyter_controller.units
+  trust       = var.jupyter_controller.trust
+  constraints = var.jupyter_controller.constraints
+  config      = var.jupyter_controller.config
+  resources   = var.jupyter_controller.resources
+}
+
+# Notebook Web App application
+resource "juju_application" "jupyter_ui" {
+  charm {
+    name     = "jupyter-ui"
+    channel  = var.jupyter_ui.channel
+    revision = var.jupyter_ui.revision
+  }
+
+  model_uuid  = var.model_uuid
+  name        = var.jupyter_ui.app_name
+  units       = var.jupyter_ui.units
+  trust       = var.jupyter_ui.trust
+  constraints = var.jupyter_ui.constraints
+  config      = var.jupyter_ui.config
+  resources   = var.jupyter_ui.resources
+}

--- a/terraform-refactoring/components/notebooks/integrations.tf
+++ b/terraform-refactoring/components/notebooks/integrations.tf
@@ -1,0 +1,104 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Notebook Web App dashboard-links integration (kubeflow-dashboard:links -> jupyter-ui)
+resource "juju_integration" "jupyter_ui_dashboard_links" {
+  count      = var.dashboard_links != null ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.jupyter_ui.name
+    endpoint = "dashboard-links"
+  }
+
+  application {
+    name      = var.dashboard_links.kind == "endpoint" ? var.dashboard_links.name : null
+    endpoint  = var.dashboard_links.kind == "endpoint" ? var.dashboard_links.endpoint : null
+    offer_url = var.dashboard_links.kind == "offer" ? var.dashboard_links.url : null
+  }
+}
+
+# Notebook Web App ingress integration - sidecar (istio-pilot:ingress -> jupyter-ui)
+resource "juju_integration" "jupyter_ui_ingress" {
+  count      = var.ingress != null ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.jupyter_ui.name
+    endpoint = "ingress"
+  }
+
+  application {
+    name      = var.ingress.kind == "endpoint" ? var.ingress.name : null
+    endpoint  = var.ingress.kind == "endpoint" ? var.ingress.endpoint : null
+    offer_url = var.ingress.kind == "offer" ? var.ingress.url : null
+  }
+}
+
+# Notebook Web App istio-ingress-route integration - ambient (istio-ingress-k8s:istio-ingress-route -> jupyter-ui)
+resource "juju_integration" "notebook_web_app_istio_ingress_route" {
+  count      = var.istio_ingress_route != null ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.jupyter_ui.name
+    endpoint = "istio-ingress-route"
+  }
+
+  application {
+    name      = var.istio_ingress_route.kind == "endpoint" ? var.istio_ingress_route.name : null
+    endpoint  = var.istio_ingress_route.kind == "endpoint" ? var.istio_ingress_route.endpoint : null
+    offer_url = var.istio_ingress_route.kind == "offer" ? var.istio_ingress_route.url : null
+  }
+}
+
+# Jupyter Controller gateway-metadata integration - ambient (istio-ingress-k8s:gateway-metadata -> jupyter-controller)
+resource "juju_integration" "jupyter_controller_gateway_metadata" {
+  count      = var.gateway_metadata != null ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.jupyter_controller.name
+    endpoint = "gateway-metadata"
+  }
+
+  application {
+    name      = var.gateway_metadata.kind == "endpoint" ? var.gateway_metadata.name : null
+    endpoint  = var.gateway_metadata.kind == "endpoint" ? var.gateway_metadata.endpoint : null
+    offer_url = var.gateway_metadata.kind == "offer" ? var.gateway_metadata.url : null
+  }
+}
+
+# Ambient service-mesh integrations (istio-beacon-k8s:service-mesh -> Notebooks apps)
+
+resource "juju_integration" "jupyter-controller_service_mesh" {
+  count      = var.service_mesh != null ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.jupyter_controller.name
+    endpoint = "service-mesh"
+  }
+
+  application {
+    name      = var.service_mesh.kind == "endpoint" ? var.service_mesh.name : null
+    endpoint  = var.service_mesh.kind == "endpoint" ? var.service_mesh.endpoint : null
+    offer_url = var.service_mesh.kind == "offer" ? var.service_mesh.url : null
+  }
+}
+
+resource "juju_integration" "jupyter_ui_service_mesh" {
+  count      = var.service_mesh != null ? 1 : 0
+  model_uuid = var.model_uuid
+
+  application {
+    name     = juju_application.jupyter_ui.name
+    endpoint = "service-mesh"
+  }
+
+  application {
+    name      = var.service_mesh.kind == "endpoint" ? var.service_mesh.name : null
+    endpoint  = var.service_mesh.kind == "endpoint" ? var.service_mesh.endpoint : null
+    offer_url = var.service_mesh.kind == "offer" ? var.service_mesh.url : null
+  }
+}

--- a/terraform-refactoring/components/notebooks/outputs.tf
+++ b/terraform-refactoring/components/notebooks/outputs.tf
@@ -1,0 +1,32 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "components" {
+  description = "Map of the deployed Notebooks applications"
+  value = {
+    jupyter_controller = juju_application.jupyter_controller
+    jupyter_ui         = juju_application.jupyter_ui
+  }
+}
+
+output "requires" {
+  description = "Map of endpoints required by this component from other components (inbound relations)"
+  value = {
+    jupyter_ui_dashboard_links = {
+      name     = juju_application.jupyter_ui.name
+      endpoint = "dashboard-links"
+    }
+    jupyter_ui_ingress = {
+      name     = juju_application.jupyter_ui.name
+      endpoint = "ingress"
+    }
+    jupyter_ui_istio_ingress_route = {
+      name     = juju_application.jupyter_ui.name
+      endpoint = "istio-ingress-route"
+    }
+    jupyter_controller_gateway_metadata = {
+      name     = juju_application.jupyter_controller.name
+      endpoint = "gateway-metadata"
+    }
+  }
+}

--- a/terraform-refactoring/components/notebooks/variables.tf
+++ b/terraform-refactoring/components/notebooks/variables.tf
@@ -1,0 +1,173 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "model_uuid" {
+  description = "UUID of the Juju model where Notebooks is deployed"
+  type        = string
+  nullable    = false
+}
+
+variable "dashboard_links" {
+  description = "Kubeflow Dashboard links provider for jupyter-ui from kubeflow-dashboard:links (supports same-model endpoint or cross-model offer)"
+  type = object({
+    kind     = string
+    name     = optional(string, null)
+    endpoint = optional(string, null)
+    url      = optional(string, null)
+  })
+  nullable = true
+  default  = null
+
+  validation {
+    condition     = var.dashboard_links == null || contains(["endpoint", "offer"], var.dashboard_links.kind)
+    error_message = "The 'kind' attribute must be either 'endpoint' or 'offer'."
+  }
+
+  validation {
+    condition     = var.dashboard_links == null || var.dashboard_links.kind != "endpoint" || (var.dashboard_links.kind != null && var.dashboard_links.kind != "" && var.dashboard_links.name != null && var.dashboard_links.name != "")
+    error_message = "Both 'name' and 'endpoint' attributes must be provided for an in-model integration."
+  }
+
+  validation {
+    condition     = var.dashboard_links == null || var.dashboard_links.kind != "offer" || (var.dashboard_links.url != null && var.dashboard_links.url != "")
+    error_message = "The 'url' attribute must be provided for a cross-model offer integration."
+  }
+}
+
+variable "ingress" {
+  description = "Ingress provider for notebook-web-app from istio-pilot:ingress (supports same-model endpoint or cross-model offer)"
+  type = object({
+    kind     = string
+    name     = optional(string, null)
+    endpoint = optional(string, null)
+    url      = optional(string, null)
+  })
+  nullable = true
+  default  = null
+
+  validation {
+    condition     = var.ingress == null || contains(["endpoint", "offer"], var.ingress.kind)
+    error_message = "The 'kind' attribute must be either 'endpoint' or 'offer'."
+  }
+
+  validation {
+    condition     = var.ingress == null || var.ingress.kind != "endpoint" || (var.ingress.kind != null && var.ingress.kind != "" && var.ingress.name != null && var.ingress.name != "")
+    error_message = "Both 'name' and 'endpoint' attributes must be provided for an in-model integration."
+  }
+
+  validation {
+    condition     = var.ingress == null || var.ingress.kind != "offer" || (var.ingress.url != null && var.ingress.url != "")
+    error_message = "The 'url' attribute must be provided for a cross-model offer integration."
+  }
+}
+
+variable "istio_ingress_route" {
+  description = "Istio ingress route provider for notebook-web-app from istio-ingress-k8s:istio-ingress-route (supports same-model endpoint or cross-model offer)"
+  type = object({
+    kind     = string
+    name     = optional(string, null)
+    endpoint = optional(string, null)
+    url      = optional(string, null)
+  })
+  nullable = true
+  default  = null
+
+  validation {
+    condition     = var.istio_ingress_route == null || contains(["endpoint", "offer"], var.istio_ingress_route.kind)
+    error_message = "The 'kind' attribute must be either 'endpoint' or 'offer'."
+  }
+
+  validation {
+    condition     = var.istio_ingress_route == null || var.istio_ingress_route.kind != "endpoint" || (var.istio_ingress_route.kind != null && var.istio_ingress_route.kind != "" && var.istio_ingress_route.name != null && var.istio_ingress_route.name != "")
+    error_message = "Both 'name' and 'endpoint' attributes must be provided for an in-model integration."
+  }
+
+  validation {
+    condition     = var.istio_ingress_route == null || var.istio_ingress_route.kind != "offer" || (var.istio_ingress_route.url != null && var.istio_ingress_route.url != "")
+    error_message = "The 'url' attribute must be provided for a cross-model offer integration."
+  }
+}
+
+variable "gateway_metadata" {
+  description = "Gateway metadata provider for jupyter-controller from istio-ingress-k8s:gateway-metadata (supports same-model endpoint or cross-model offer)"
+  type = object({
+    kind     = string
+    name     = optional(string, null)
+    endpoint = optional(string, null)
+    url      = optional(string, null)
+  })
+  nullable = true
+  default  = null
+
+  validation {
+    condition     = var.gateway_metadata == null || contains(["endpoint", "offer"], var.gateway_metadata.kind)
+    error_message = "The 'kind' attribute must be either 'endpoint' or 'offer'."
+  }
+
+  validation {
+    condition     = var.gateway_metadata == null || var.gateway_metadata.kind != "endpoint" || (var.gateway_metadata.name != null && var.gateway_metadata.name != "")
+    error_message = "Both 'name' and 'endpoint' attributes must be provided for an in-model integration."
+  }
+
+  validation {
+    condition     = var.gateway_metadata == null || var.gateway_metadata.kind != "offer" || (var.gateway_metadata.url != null && var.gateway_metadata.url != "")
+    error_message = "The 'url' attribute must be provided for a cross-model offer integration."
+  }
+}
+
+variable "service_mesh" {
+  description = "Service mesh provider for Notebooks applications from istio-beacon-k8s:service-mesh (supports same-model endpoint or cross-model offer)"
+  type = object({
+    kind     = string
+    name     = optional(string, null)
+    endpoint = optional(string, null)
+    url      = optional(string, null)
+  })
+  nullable = true
+  default  = null
+
+  validation {
+    condition     = var.service_mesh == null || contains(["endpoint", "offer"], var.service_mesh.kind)
+    error_message = "The 'kind' attribute must be either 'endpoint' or 'offer'."
+  }
+
+  validation {
+    condition     = var.service_mesh == null || var.service_mesh.kind != "endpoint" || (var.service_mesh.kind != null && var.service_mesh.kind != "" && var.service_mesh.name != null && var.service_mesh.name != "")
+    error_message = "Both 'name' and 'endpoint' attributes must be provided for an in-model integration."
+  }
+
+  validation {
+    condition     = var.service_mesh == null || var.service_mesh.kind != "offer" || (var.service_mesh.url != null && var.service_mesh.url != "")
+    error_message = "The 'url' attribute must be provided for a cross-model offer integration."
+  }
+}
+
+variable "jupyter_controller" {
+  description = "Configuration for jupyter-controller application"
+  type = object({
+    app_name    = optional(string, "jupyter-controller")
+    channel     = optional(string, "1.10/stable")
+    revision    = optional(number)
+    units       = optional(number, 1)
+    trust       = optional(bool, true)
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    resources   = optional(map(string), {})
+  })
+  default = {}
+}
+
+variable "jupyter_ui" {
+  description = "Configuration for jupyter-ui application"
+  type = object({
+    app_name    = optional(string, "jupyter-ui")
+    channel     = optional(string, "1.10/stable")
+    revision    = optional(number)
+    units       = optional(number, 1)
+    trust       = optional(bool, true)
+    constraints = optional(string, "arch=amd64")
+    config      = optional(map(string), {})
+    resources   = optional(map(string), {})
+  })
+  default = {}
+}

--- a/terraform-refactoring/components/notebooks/versions.tf
+++ b/terraform-refactoring/components/notebooks/versions.tf
@@ -1,0 +1,12 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.1.1"
+    }
+  }
+}

--- a/terraform-refactoring/products/kubeflow/README.md
+++ b/terraform-refactoring/products/kubeflow/README.md
@@ -18,7 +18,7 @@
 | ---- | ------ | ------- |
 | <a name="module_ambient"></a> [ambient](#module\_ambient) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/istio-ambient | feat/terraform-refactor |
 | <a name="module_auth"></a> [auth](#module\_auth) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/auth | feat/terraform-refactor |
-| <a name="module_core"></a> [core](#module\_core) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/core | feat/terraform-refactor |
+| <a name="module_core"></a> [core](#module\_core) | ../../components/core | n/a |
 | <a name="module_istio"></a> [istio](#module\_istio) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/istio-sidecar | feat/terraform-refactor |
 | <a name="module_katib"></a> [katib](#module\_katib) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/katib | feat/terraform-refactor |
 | <a name="module_kfp"></a> [kfp](#module\_kfp) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/kfp | feat/terraform-refactor |
@@ -39,6 +39,8 @@
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_admission_webhook_config"></a> [admission\_webhook\_config](#input\_admission\_webhook\_config) | Configuration for admission-webhook application | `map(string)` | `{}` | no |
+| <a name="input_admission_webhook_revision"></a> [admission\_webhook\_revision](#input\_admission\_webhook\_revision) | Revision of the admission-webhook application | `number` | `null` | no |
 | <a name="input_argo_controller_config"></a> [argo\_controller\_config](#input\_argo\_controller\_config) | Configuration for argo-controller application | `map(string)` | `{}` | no |
 | <a name="input_argo_controller_revision"></a> [argo\_controller\_revision](#input\_argo\_controller\_revision) | Revision of the argo-controller application | `number` | `null` | no |
 | <a name="input_create_model"></a> [create\_model](#input\_create\_model) | Create a Juju model named kubeflow for this product deployment | `bool` | `true` | no |

--- a/terraform-refactoring/products/kubeflow/README.md
+++ b/terraform-refactoring/products/kubeflow/README.md
@@ -20,10 +20,11 @@
 | <a name="module_auth"></a> [auth](#module\_auth) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/auth | feat/terraform-refactor |
 | <a name="module_core"></a> [core](#module\_core) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/core | feat/terraform-refactor |
 | <a name="module_istio"></a> [istio](#module\_istio) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/istio-sidecar | feat/terraform-refactor |
-| <a name="module_katib"></a> [katib](#module\_katib) | ../../components/katib | n/a |
-| <a name="module_kfp"></a> [kfp](#module\_kfp) | ../../components/kfp | n/a |
+| <a name="module_katib"></a> [katib](#module\_katib) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/katib | feat/terraform-refactor |
+| <a name="module_kfp"></a> [kfp](#module\_kfp) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/kfp | feat/terraform-refactor |
 | <a name="module_minio"></a> [minio](#module\_minio) | git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/charms/minio | feat/terraform-refactor |
 | <a name="module_mysql"></a> [mysql](#module\_mysql) | git::https://github.com/canonical/mysql-k8s-operator//terraform | 58072079edc97bace08b6ff9c8f380b94867ebd4 |
+| <a name="module_notebooks"></a> [notebooks](#module\_notebooks) | ../../components/notebooks | n/a |
 | <a name="module_tensorboard"></a> [tensorboard](#module\_tensorboard) | ../../components/tensorboard | n/a |
 
 ## Resources
@@ -45,6 +46,7 @@
 | <a name="input_dex_auth_revision"></a> [dex\_auth\_revision](#input\_dex\_auth\_revision) | Revision of the dex-auth application | `number` | `null` | no |
 | <a name="input_enable_katib"></a> [enable\_katib](#input\_enable\_katib) | Whether to deploy the Katib component | `bool` | `true` | no |
 | <a name="input_enable_kfp"></a> [enable\_kfp](#input\_enable\_kfp) | Whether to deploy the KFP component | `bool` | `true` | no |
+| <a name="input_enable_notebooks"></a> [enable\_notebooks](#input\_enable\_notebooks) | Whether to deploy the Notebooks component | `bool` | `true` | no |
 | <a name="input_enable_tensorboard"></a> [enable\_tensorboard](#input\_enable\_tensorboard) | Whether to deploy the Tensorboard component | `bool` | `true` | no |
 | <a name="input_envoy_config"></a> [envoy\_config](#input\_envoy\_config) | Configuration for envoy application | `map(string)` | `{}` | no |
 | <a name="input_envoy_revision"></a> [envoy\_revision](#input\_envoy\_revision) | Revision of the envoy application | `number` | `null` | no |
@@ -57,8 +59,12 @@
 | <a name="input_istio_k8s_config"></a> [istio\_k8s\_config](#input\_istio\_k8s\_config) | Configuration for istio-k8s application | `map(string)` | `{}` | no |
 | <a name="input_istio_k8s_platform"></a> [istio\_k8s\_platform](#input\_istio\_k8s\_platform) | Platform configuration for istio-k8s | `string` | `""` | no |
 | <a name="input_istio_k8s_revision"></a> [istio\_k8s\_revision](#input\_istio\_k8s\_revision) | Revision of the istio-k8s application | `number` | `null` | no |
-| <a name="input_istio_pilot_config"></a> [istio\_pilot\_config](#input\_istio\_pilot\_config) | Configuration for istio-pilot application | `map(string)` | `{}` | no |
+| <a name="input_istio_pilot_config"></a> [istio\_pilot\_config](#input\_istio\_pilot\_config) | Configuration for istio-pilot application | `map(string)` | <pre>{<br/>  "default-gateway": "kubeflow-gateway"<br/>}</pre> | no |
 | <a name="input_istio_pilot_revision"></a> [istio\_pilot\_revision](#input\_istio\_pilot\_revision) | Revision of the istio-pilot application | `number` | `null` | no |
+| <a name="input_jupyter_controller_config"></a> [jupyter\_controller\_config](#input\_jupyter\_controller\_config) | Configuration for jupyter-controller application | `map(string)` | `{}` | no |
+| <a name="input_jupyter_controller_revision"></a> [jupyter\_controller\_revision](#input\_jupyter\_controller\_revision) | Revision of the jupyter-controller application | `number` | `null` | no |
+| <a name="input_jupyter_ui_config"></a> [jupyter\_ui\_config](#input\_jupyter\_ui\_config) | Configuration for jupyter-ui application | `map(string)` | `{}` | no |
+| <a name="input_jupyter_ui_revision"></a> [jupyter\_ui\_revision](#input\_jupyter\_ui\_revision) | Revision of the jupyter-ui application | `number` | `null` | no |
 | <a name="input_katib_controller_config"></a> [katib\_controller\_config](#input\_katib\_controller\_config) | Configuration for katib-controller application | `map(string)` | `{}` | no |
 | <a name="input_katib_controller_revision"></a> [katib\_controller\_revision](#input\_katib\_controller\_revision) | Revision of the katib-controller application | `number` | `null` | no |
 | <a name="input_katib_db_manager_config"></a> [katib\_db\_manager\_config](#input\_katib\_db\_manager\_config) | Configuration for katib-db-manager application | `map(string)` | `{}` | no |

--- a/terraform-refactoring/products/kubeflow/locals.tf
+++ b/terraform-refactoring/products/kubeflow/locals.tf
@@ -29,6 +29,9 @@ locals {
   # Katib Component
   katib_channel = "latest/${var.risk}"
 
+  # Notebooks Component
+  notebooks_channel = "latest/${var.risk}"
+
   # Tensorboard Component
   tensorboard_channel = "latest/${var.risk}"
 

--- a/terraform-refactoring/products/kubeflow/locals.tf
+++ b/terraform-refactoring/products/kubeflow/locals.tf
@@ -7,6 +7,7 @@ locals {
   oidc_gatekeeper_channel = "latest/${var.risk}"
 
   # Core Component
+  admission_webhook_channel       = "latest/${var.risk}"
   kubeflow_dashboard_channel      = "latest/${var.risk}"
   kubeflow_profiles_channel       = "latest/${var.risk}"
   kubeflow_roles_channel          = "latest/${var.risk}"

--- a/terraform-refactoring/products/kubeflow/main.tf
+++ b/terraform-refactoring/products/kubeflow/main.tf
@@ -90,10 +90,15 @@ module "auth" {
 module "core" {
   depends_on = [module.istio, module.ambient, module.auth]
 
-  source = "git::https://github.com/canonical/charmed-kubeflow-solutions//terraform-refactoring/components/core?ref=feat/terraform-refactor"
+  source = "../../components/core"
 
   model_uuid = var.create_model ? juju_model.kubeflow[0].uuid : var.model_uuid
 
+  admission_webhook = {
+    channel  = local.admission_webhook_channel
+    revision = var.admission_webhook_revision
+    config   = var.admission_webhook_config
+  }
   kubeflow_dashboard = {
     channel  = local.kubeflow_dashboard_channel
     revision = var.kubeflow_dashboard_revision

--- a/terraform-refactoring/products/kubeflow/main.tf
+++ b/terraform-refactoring/products/kubeflow/main.tf
@@ -364,6 +364,12 @@ module "notebooks" {
     endpoint = module.istio[0].provides.istio_pilot_ingress.endpoint
   } : null
 
+  gateway_metadata = var.service_mesh_type == "ambient" ? {
+    kind     = "endpoint"
+    name     = module.ambient[0].provides.istio_ingress_k8s_gateway_metadata.name
+    endpoint = module.ambient[0].provides.istio_ingress_k8s_gateway_metadata.endpoint
+  } : null
+
   service_mesh = var.service_mesh_type == "ambient" ? {
     kind     = "endpoint"
     name     = module.ambient[0].provides.istio_beacon_k8s_service_mesh.name

--- a/terraform-refactoring/products/kubeflow/main.tf
+++ b/terraform-refactoring/products/kubeflow/main.tf
@@ -339,6 +339,51 @@ module "kfp" {
   }
 }
 
+module "notebooks" {
+  count      = var.enable_notebooks ? 1 : 0
+  depends_on = [module.core, module.istio, module.ambient]
+
+  source = "../../components/notebooks"
+
+  model_uuid = var.create_model ? juju_model.kubeflow[0].uuid : var.model_uuid
+
+  dashboard_links = {
+    kind     = "endpoint"
+    name     = module.core.provides.kubeflow_dashboard_links.name
+    endpoint = module.core.provides.kubeflow_dashboard_links.endpoint
+  }
+
+  ingress = var.service_mesh_type == "sidecar" ? {
+    kind     = "endpoint"
+    name     = module.istio[0].provides.istio_pilot_ingress.name
+    endpoint = module.istio[0].provides.istio_pilot_ingress.endpoint
+  } : null
+
+  service_mesh = var.service_mesh_type == "ambient" ? {
+    kind     = "endpoint"
+    name     = module.ambient[0].provides.istio_beacon_k8s_service_mesh.name
+    endpoint = module.ambient[0].provides.istio_beacon_k8s_service_mesh.endpoint
+  } : null
+
+  istio_ingress_route = var.service_mesh_type == "ambient" ? {
+    kind     = "endpoint"
+    name     = module.ambient[0].provides.istio_ingress_k8s_istio_ingress_route.name
+    endpoint = module.ambient[0].provides.istio_ingress_k8s_istio_ingress_route.endpoint
+  } : null
+
+  jupyter_controller = {
+    channel  = local.notebooks_channel
+    revision = var.jupyter_controller_revision
+    config   = var.jupyter_controller_config
+  }
+
+  jupyter_ui = {
+    channel  = local.notebooks_channel
+    revision = var.jupyter_ui_revision
+    config   = var.jupyter_ui_config
+  }
+}
+
 module "tensorboard" {
   count      = var.enable_tensorboard ? 1 : 0
   depends_on = [module.core, module.istio, module.ambient]

--- a/terraform-refactoring/products/kubeflow/variables.tf
+++ b/terraform-refactoring/products/kubeflow/variables.tf
@@ -59,6 +59,18 @@ variable "oidc_gatekeeper_config" {
 
 # Core Component Applications
 
+variable "admission_webhook_revision" {
+  description = "Revision of the admission-webhook application"
+  type        = number
+  default     = null
+}
+
+variable "admission_webhook_config" {
+  description = "Configuration for admission-webhook application"
+  type        = map(string)
+  default     = {}
+}
+
 variable "kubeflow_dashboard_revision" {
   description = "Revision of the kubeflow-dashboard application"
   type        = number

--- a/terraform-refactoring/products/kubeflow/variables.tf
+++ b/terraform-refactoring/products/kubeflow/variables.tf
@@ -305,7 +305,7 @@ variable "istio_pilot_revision" {
 variable "istio_pilot_config" {
   description = "Configuration for istio-pilot application"
   type        = map(string)
-  default     = {}
+  default     = { default-gateway = "kubeflow-gateway" }
 }
 
 variable "istio_ingressgateway_revision" {
@@ -417,6 +417,38 @@ variable "katib_ui_revision" {
 
 variable "katib_ui_config" {
   description = "Configuration for katib-ui application"
+  type        = map(string)
+  default     = {}
+}
+
+# Notebooks Component Applications
+
+variable "enable_notebooks" {
+  description = "Whether to deploy the Notebooks component"
+  type        = bool
+  default     = true
+}
+
+variable "jupyter_controller_revision" {
+  description = "Revision of the jupyter-controller application"
+  type        = number
+  default     = null
+}
+
+variable "jupyter_controller_config" {
+  description = "Configuration for jupyter-controller application"
+  type        = map(string)
+  default     = {}
+}
+
+variable "jupyter_ui_revision" {
+  description = "Revision of the jupyter-ui application"
+  type        = number
+  default     = null
+}
+
+variable "jupyter_ui_config" {
+  description = "Configuration for jupyter-ui application"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
This PR adds missing `admission-webhook` application to Core component.
This PR sets default config option `default-gateway` of `istio-pilot` charm to `kubeflow-gateway` (required for notebooks).
This PR adds `jupyter-controller` and `jupyter-ui` as `Notebooks` component.
This PR closes #166.