### PR TITLE
feat: Update kfp charms to `2.16` in release candidate branch

### DIFF
--- a/.github/dependencies.yaml
+++ b/.github/dependencies.yaml
@@ -1,5 +1,5 @@
 CKF_BRANCH: "track/1.11-rc"
 K8S_VERSION: "1.32"
 JUJU_VERSION: "3.6"
-UATS_BRANCH: "track/1.11-rc"
+UATS_BRANCH: "kf-8655-rc-branch"
 RISK: "stable"

--- a/.github/dependencies.yaml
+++ b/.github/dependencies.yaml
@@ -1,5 +1,5 @@
-CKF_BRANCH: "track/1.11"
+CKF_BRANCH: "track/1.11-rc"
 K8S_VERSION: "1.32"
 JUJU_VERSION: "3.6"
-UATS_BRANCH: "track/1.11"
+UATS_BRANCH: "track/1.11-rc"
 RISK: "stable"

--- a/.github/dependencies.yaml
+++ b/.github/dependencies.yaml
@@ -1,5 +1,5 @@
 CKF_BRANCH: "track/1.11-rc"
 K8S_VERSION: "1.32"
 JUJU_VERSION: "3.6"
-UATS_BRANCH: "kf-8655-rc-branch"
+UATS_BRANCH: "track/1.11-rc"
 RISK: "stable"

--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -39,7 +39,7 @@ jobs:
             uats_branch: main
             uats:
               env: kubeflow-remote
-              extra-args:
+              extra-args: --bundle "file:assets/versions-ambient.yaml"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-to-microk8s.yaml
+++ b/.github/workflows/deploy-to-microk8s.yaml
@@ -40,7 +40,7 @@ jobs:
             uats_branch: main
             uats:
               env: kubeflow-remote
-              extra-args:
+              extra-args: --bundle "file:assets/versions-ambient.yaml"
         pod-security-standards:
           - policy: privileged
             istio-cni-bin-dir: ""  # meaning Istio CNI disabled

--- a/modules/kubeflow-ambient/applications.tf
+++ b/modules/kubeflow-ambient/applications.tf
@@ -163,7 +163,7 @@ module "kserve_controller" {
   source     = "git::https://github.com/canonical/kserve-operators//charms/kserve-controller/terraform?ref=main"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   config = {
-    deployment-mode = "rawdeployment",
+    deployment-mode = "standard",
     http-proxy      = var.http_proxy,
     https-proxy     = var.https_proxy,
     no-proxy        = var.no_proxy,

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -112,13 +112,13 @@ module "katib_ui" {
 }
 
 module "kfp_api" {
-  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-api/terraform?ref=track/2.15"
+  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-api/terraform?ref=track/2.16"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_api_revision
   config = {
     object-store-bucket-name = var.kfp_api_object_store_bucket_name
   }
-  channel = "2.15/${var.risk}"
+  channel = "2.16/edge"
 }
 
 module "kfp_db" {
@@ -136,52 +136,52 @@ module "kfp_db" {
 }
 
 module "kfp_metadata_writer" {
-  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-metadata-writer/terraform?ref=track/2.15"
+  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-metadata-writer/terraform?ref=track/2.16"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_metadata_writer_revision
-  channel    = "2.15/${var.risk}"
+  channel    = "2.16/edge"
 }
 
 module "kfp_persistence" {
-  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-persistence/terraform?ref=track/2.15"
+  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-persistence/terraform?ref=track/2.16"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_persistence_revision
-  channel    = "2.15/${var.risk}"
+  channel    = "2.16/edge"
 }
 
 module "kfp_profile_controller" {
-  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-profile-controller/terraform?ref=track/2.15"
+  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-profile-controller/terraform?ref=track/2.16"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_profile_controller_revision
-  channel    = "2.15/${var.risk}"
+  channel    = "2.16/edge"
 }
 
 module "kfp_schedwf" {
-  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-schedwf/terraform?ref=track/2.15"
+  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-schedwf/terraform?ref=track/2.16"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_schedwf_revision
-  channel    = "2.15/${var.risk}"
+  channel    = "2.16/edge"
 }
 
 module "kfp_ui" {
-  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-ui/terraform?ref=track/2.15"
+  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-ui/terraform?ref=track/2.16"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_ui_revision
-  channel    = "2.15/${var.risk}"
+  channel    = "2.16/edge"
 }
 
 module "kfp_viewer" {
-  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-viewer/terraform?ref=track/2.15"
+  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-viewer/terraform?ref=track/2.16"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_viewer_revision
-  channel    = "2.15/${var.risk}"
+  channel    = "2.16/edge"
 }
 
 module "kfp_viz" {
-  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-viz/terraform?ref=track/2.15"
+  source     = "git::https://github.com/canonical/kfp-operators//charms/kfp-viz/terraform?ref=track/2.16"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kfp_viz_revision
-  channel    = "2.15/${var.risk}"
+  channel    = "2.16/edge"
 }
 
 module "knative_eventing" {


### PR DESCRIPTION
## Summary
This PR updates the `kubeflow` module to include track `2.16` of the 8 kfp charms. Note that since we haven't released to `2.16/stable` yet, we're using the `2.16/edge` channel.

Part of #173