### PR TITLE
chore: migrate to new Kubeflow Trainer repo

### DIFF
--- a/modules/kubeflow-ambient/applications.tf
+++ b/modules/kubeflow-ambient/applications.tf
@@ -203,7 +203,7 @@ module "kubeflow_roles" {
 
 module "kubeflow_trainer" {
   count      = var.kubeflow_trainer_v2 ? 1 : 0
-  source     = "git::https://github.com/canonical/training-operator//terraform?ref=main-v2"
+  source     = "git::https://github.com/canonical/kubeflow-trainer-operator//terraform?ref=main"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kubeflow_trainer_revision
   channel    = local.channel_latest_edge

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -254,7 +254,7 @@ module "kubeflow_roles" {
 
 module "kubeflow_trainer" {
   count      = var.kubeflow_trainer_v2 ? 1 : 0
-  source     = "git::https://github.com/canonical/training-operator//terraform?ref=main-v2"
+  source     = "git::https://github.com/canonical/kubeflow-trainer-operator//terraform?ref=main"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kubeflow_trainer_revision
   channel    = "${local.track}/${var.risk}"


### PR DESCRIPTION
This PR migrates the Terraform module sources for Kubeflow Trainer Operator to the new repository.