### PR TITLE
chore: migrate to new Kubeflow Trainer repo (track 1.11)

### DIFF
--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -39,7 +39,7 @@ jobs:
             uats_branch: main
             uats:
               env: kubeflow-remote
-              extra-args:
+              extra-args: --bundle "file:assets/versions-ambient.yaml"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-to-microk8s.yaml
+++ b/.github/workflows/deploy-to-microk8s.yaml
@@ -40,7 +40,7 @@ jobs:
             uats_branch: main
             uats:
               env: kubeflow-remote
-              extra-args:
+              extra-args: --bundle "file:assets/versions-ambient.yaml"
         pod-security-standards:
           - policy: privileged
             istio-cni-bin-dir: ""  # meaning Istio CNI disabled

--- a/modules/kubeflow-ambient/applications.tf
+++ b/modules/kubeflow-ambient/applications.tf
@@ -203,7 +203,7 @@ module "kubeflow_roles" {
 
 module "kubeflow_trainer" {
   count      = var.kubeflow_trainer_v2 ? 1 : 0
-  source     = "git::https://github.com/canonical/training-operator//terraform?ref=main-v2"
+  source     = "git::https://github.com/canonical/kubeflow-trainer-operator//terraform?ref=main"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kubeflow_trainer_revision
   channel    = local.channel_latest_edge

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -254,7 +254,7 @@ module "kubeflow_roles" {
 
 module "kubeflow_trainer" {
   count      = var.kubeflow_trainer_v2 ? 1 : 0
-  source     = "git::https://github.com/canonical/training-operator//terraform?ref=track/2.1"
+  source     = "git::https://github.com/canonical/kubeflow-trainer-operator//terraform?ref=track/2.1"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kubeflow_trainer_revision
   channel    = "2.1/edge"


### PR DESCRIPTION
This PR migrates the Terraform module sources for Kubeflow Trainer Operator to the new repository.