### PR TITLE
chore: migrate to new Kubeflow Trainer repo (track 1.10)

### DIFF
--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -258,7 +258,7 @@ module "kubeflow_roles" {
 
 module "kubeflow_trainer" {
   count      = var.kubeflow_trainer_v2 ? 1 : 0
-  source     = "git::https://github.com/canonical/training-operator//terraform?ref=track/2.0"
+  source     = "git::https://github.com/canonical/kubeflow-trainer-operator//terraform?ref=track/2.0"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
   revision   = var.kubeflow_trainer_revision
   channel    = "2.0/edge"


### PR DESCRIPTION
This PR migrates the Terraform module sources for Kubeflow Trainer Operator to the new repository.