### PR TITLE
fix: enable mlflow-ambient tests

### DIFF
--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -45,10 +45,6 @@ jobs:
           - product: feast
             uats:
               env: feast-remote
-        exclude:
-          # disabled due to https://github.com/canonical/mlflow-operator/issues/410
-          - product: mlflow
-            service-mesh-type: ambient
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Enable mlflow-ambient tests in the test matrix after fixing https://github.com/canonical/mlflow-operator/issues/410