### PR TITLE
[PRA-7] chore: unpin images

### DIFF
--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -39,7 +39,7 @@ jobs:
           - module: kubeflow-spark
             tf-vars-file: examples/tfvars.json
             risk: stable
-            uats_branch: pra-7-backport-uats
+            uats_branch: track/1.10
             uats:
               env: spark-remote
               extra-args: --test-image ghcr.io/canonical/charmed-spark-jupyterlab:3.5-22.04_stable --bundle ""

--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -42,7 +42,7 @@ jobs:
             uats_branch: main # TODO: Run Spark tests against ${{ inputs.uats_branch }} once UATs backported to track/1.x
             uats:
               env: spark-remote
-              extra-args: --test-image ghcr.io/canonical/charmed-spark-jupyterlab:3.5-22.04_edge@sha256:72a6e89985e35e0920fb40c063b3287425760ebf823b129a87143d5ec0e99af7
+              extra-args: --test-image ghcr.io/canonical/charmed-spark-jupyterlab:3.5-22.04_stable
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -42,7 +42,7 @@ jobs:
             uats_branch: pra-7-backport-uats
             uats:
               env: spark-remote
-              extra-args: --test-image ghcr.io/canonical/charmed-spark-jupyterlab:3.5-22.04_stable --bunlde ""
+              extra-args: --test-image ghcr.io/canonical/charmed-spark-jupyterlab:3.5-22.04_stable --bundle ""
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-to-k8s.yaml
+++ b/.github/workflows/deploy-to-k8s.yaml
@@ -31,18 +31,18 @@ jobs:
           - module: kubeflow-mlflow
             uats:
               env: uats-remote
-              extra-args: --filter "not feast and not spark" --include-kubeflow-trainer-tests
+              extra-args: --filter "not feast and not spark"
           - module: kubeflow-feast
             uats:
               env: feast-remote
               extra-args: ""
           - module: kubeflow-spark
             tf-vars-file: examples/tfvars.json
-            risk: edge # TODO: Run Spark tests with Kubeflow from `stable` risk once all changes for Spark integration are released to stable
-            uats_branch: main # TODO: Run Spark tests against ${{ inputs.uats_branch }} once UATs backported to track/1.x
+            risk: stable
+            uats_branch: pra-7-backport-uats
             uats:
               env: spark-remote
-              extra-args: --test-image ghcr.io/canonical/charmed-spark-jupyterlab:3.5-22.04_stable
+              extra-args: --test-image ghcr.io/canonical/charmed-spark-jupyterlab:3.5-22.04_stable --bunlde ""
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-to-microk8s.yaml
+++ b/.github/workflows/deploy-to-microk8s.yaml
@@ -38,12 +38,12 @@ jobs:
               env: feast-remote
               extra-args: ""
           - module: kubeflow-spark
-            risk: edge # TODO: Run Spark tests with Kubeflow from `stable` risk once all changes for Spark integration are released to stable
-            uats_branch: main # TODO: Run Spark tests against ${{ inputs.uats_branch }} once UATs backported to track/1.x
+            risk: stable
+            uats_branch: pra-7-backport-uats 
             tf-vars-file: examples/tfvars.json
             uats:
               env: spark-remote
-              extra-args: --test-image ghcr.io/canonical/charmed-spark-jupyterlab:3.5-22.04_stable
+              extra-args: --test-image ghcr.io/canonical/charmed-spark-jupyterlab:3.5-22.04_stable --bundle ""
         pod-security-standards:
           - policy: privileged
             istio-cni-bin-dir: ""  # meaning Istio CNI disabled

--- a/.github/workflows/deploy-to-microk8s.yaml
+++ b/.github/workflows/deploy-to-microk8s.yaml
@@ -43,7 +43,7 @@ jobs:
             tf-vars-file: examples/tfvars.json
             uats:
               env: spark-remote
-              extra-args: --test-image ghcr.io/canonical/charmed-spark-jupyterlab:3.5-22.04_edge@sha256:72a6e89985e35e0920fb40c063b3287425760ebf823b129a87143d5ec0e99af7
+              extra-args: --test-image ghcr.io/canonical/charmed-spark-jupyterlab:3.5-22.04_stable
         pod-security-standards:
           - policy: privileged
             istio-cni-bin-dir: ""  # meaning Istio CNI disabled

--- a/.github/workflows/deploy-to-microk8s.yaml
+++ b/.github/workflows/deploy-to-microk8s.yaml
@@ -39,7 +39,7 @@ jobs:
               extra-args: ""
           - module: kubeflow-spark
             risk: stable
-            uats_branch: pra-7-backport-uats 
+            uats_branch: track/1.10
             tf-vars-file: examples/tfvars.json
             uats:
               env: spark-remote

--- a/modules/kubeflow-spark/variables.tf
+++ b/modules/kubeflow-spark/variables.tf
@@ -435,5 +435,5 @@ variable "kubeflow_spark_service_account" {
 variable "kubeflow_spark_profile" {
   description = "The name of the Kubeflow profile where Spark needs to be accessible."
   type        = string
-  default     = "admin"
+  default     = "*"
 }


### PR DESCRIPTION
As discussed [here](https://github.com/canonical/charmed-kubeflow-solutions/pull/195/changes#r3394526869), we should unpin image sha to avoid too much maintainability burden

It depends on https://github.com/canonical/charmed-kubeflow-uats/pull/275