### PR TITLE
refactor(oidc-gatekeeper): consolidate config into map variable

### DIFF
--- a/modules/kubeflow-ambient/README.md
+++ b/modules/kubeflow-ambient/README.md
@@ -41,7 +41,7 @@ The solution module offers the following configurable inputs:
 | `minio_storage_service_endpoint`| string | MinIO storage service endpoint, required if minio_mode is 'gateway' | False |
 | `mlmd_size`| string | MLMD database storage size | False |
 | `no_proxy`| string | Value of the no_proxy environment variable | False |
-| `oidc_gatekeeper_ca_bundle`| string | Custom CA to be trusted by OIDC gatekeeper | False |
+| `oidc_gatekeeper_config`| map(string) | Config options for OIDC gatekeeper | False |
 | `opentelemetry_collector_k8s_size`| string | OpenTelemetry collector storage size | False |
 | `public_url`| string | Public URL of Kubeflow for auth/OIDC | False |
 | `risk`| string | Value for the risk to be used | False |

--- a/modules/kubeflow-ambient/applications.tf
+++ b/modules/kubeflow-ambient/applications.tf
@@ -253,11 +253,9 @@ module "minio" {
 module "oidc_gatekeeper" {
   source     = "git::https://github.com/canonical/oidc-gatekeeper-operator//terraform?ref=main"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
-  config = {
-    ca-bundle = var.oidc_gatekeeper_ca_bundle,
-  }
-  revision = var.oidc_gatekeeper_revision
-  channel  = local.channel_latest_edge
+  config     = var.oidc_gatekeeper_config
+  revision   = var.oidc_gatekeeper_revision
+  channel    = local.channel_latest_edge
 }
 
 module "pvcviewer_operator" {

--- a/modules/kubeflow-ambient/variables.tf
+++ b/modules/kubeflow-ambient/variables.tf
@@ -155,10 +155,10 @@ variable "mlmd_size" {
   default     = "10G"
 }
 
-variable "oidc_gatekeeper_ca_bundle" {
-  description = "Custom CA to be trusted by OIDC gatekeeper"
-  type        = string
-  default     = ""
+variable "oidc_gatekeeper_config" {
+  description = "Config options for OIDC gatekeeper"
+  type        = map(string)
+  default     = {}
 }
 
 variable "no_proxy" {

--- a/modules/kubeflow-mlflow/README.md
+++ b/modules/kubeflow-mlflow/README.md
@@ -51,7 +51,7 @@ The solution module offers the following configurable inputs:
 | `mlflow_nodeport`| number | The nodeport for MLflow | False |
 | `mlmd_size`| string | MLMD database storage size | False |
 | `no_proxy`| string | Value of the no_proxy environment variable | False |
-| `oidc_gatekeeper_ca_bundle`| string | Custom CA to be trusted by OIDC gatekeeper | False |
+| `oidc_gatekeeper_config`| map(string) | Config options for OIDC gatekeeper | False |
 | `opentelemetry_collector_k8s_size`| string | OpenTelemetry collector storage size | False |
 | `public_url`| string | Public URL of Kubeflow for auth/OIDC | False |
 | `risk`| string | Value for the risk to be used | False |

--- a/modules/kubeflow-mlflow/main.tf
+++ b/modules/kubeflow-mlflow/main.tf
@@ -65,7 +65,7 @@ module "kubeflow" {
   mlmd_revision                         = var.mlmd_revision
   minio_revision                        = var.minio_revision
   oidc_gatekeeper_revision              = var.oidc_gatekeeper_revision
-  oidc_gatekeeper_ca_bundle             = var.oidc_gatekeeper_ca_bundle
+  oidc_gatekeeper_config                = var.oidc_gatekeeper_config
   pvcviewer_operator_revision           = var.pvcviewer_operator_revision
   tensorboard_controller_revision       = var.tensorboard_controller_revision
   tensorboards_web_app_revision         = var.tensorboards_web_app_revision

--- a/modules/kubeflow-mlflow/variables.tf
+++ b/modules/kubeflow-mlflow/variables.tf
@@ -247,10 +247,10 @@ variable "no_proxy" {
   default     = ""
 }
 
-variable "oidc_gatekeeper_ca_bundle" {
-  description = "Custom CA to be trusted by OIDC gatekeeper"
-  type        = string
-  default     = ""
+variable "oidc_gatekeeper_config" {
+  description = "Config options for OIDC gatekeeper"
+  type        = map(string)
+  default     = {}
 }
 
 variable "public_url" {

--- a/modules/kubeflow-spark/README.md
+++ b/modules/kubeflow-spark/README.md
@@ -39,7 +39,7 @@ The solution module offers the following configurable inputs:
 | `minio_storage_service_endpoint`| string | MinIO storage service endpoint, required if minio_mode is 'gateway' | False |
 | `mlmd_size`| string | MLMD database storage size | False |
 | `no_proxy`| string | Value of the no_proxy environment variable | False |
-| `oidc_gatekeeper_ca_bundle`| string | Custom CA to be trusted by OIDC gatekeeper | False |
+| `oidc_gatekeeper_config`| map(string) | Config options for OIDC gatekeeper | False |
 | `opentelemetry_collector_k8s_size`| string | OpenTelemetry collector storage size | False |
 | `public_url`| string | Public URL of Kubeflow for auth/OIDC | False |
 | `risk`| string | Value for the risk to be used | False |

--- a/modules/kubeflow-spark/main.tf
+++ b/modules/kubeflow-spark/main.tf
@@ -63,7 +63,7 @@ module "kubeflow" {
   mlmd_revision                         = var.mlmd_revision
   minio_revision                        = var.minio_revision
   oidc_gatekeeper_revision              = var.oidc_gatekeeper_revision
-  oidc_gatekeeper_ca_bundle             = var.oidc_gatekeeper_ca_bundle
+  oidc_gatekeeper_config                = var.oidc_gatekeeper_config
   pvcviewer_operator_revision           = var.pvcviewer_operator_revision
   tensorboard_controller_revision       = var.tensorboard_controller_revision
   tensorboards_web_app_revision         = var.tensorboards_web_app_revision

--- a/modules/kubeflow-spark/variables.tf
+++ b/modules/kubeflow-spark/variables.tf
@@ -174,10 +174,10 @@ variable "no_proxy" {
   default     = ""
 }
 
-variable "oidc_gatekeeper_ca_bundle" {
-  description = "Custom CA to be trusted by OIDC gatekeeper"
-  type        = string
-  default     = ""
+variable "oidc_gatekeeper_config" {
+  description = "Config options for OIDC gatekeeper"
+  type        = map(string)
+  default     = {}
 }
 
 variable "public_url" {

--- a/modules/kubeflow/README.md
+++ b/modules/kubeflow/README.md
@@ -39,7 +39,7 @@ The solution module offers the following configurable inputs:
 | `minio_storage_service_endpoint`| string | MinIO storage service endpoint, required if minio_mode is 'gateway' | False |
 | `mlmd_size`| string | MLMD database storage size | False |
 | `no_proxy`| string | Value of the no_proxy environment variable | False |
-| `oidc_gatekeeper_ca_bundle`| string | Custom CA to be trusted by OIDC gatekeeper | False |
+| `oidc_gatekeeper_config`| map(string) | Config options for OIDC gatekeeper | False |
 | `opentelemetry_collector_k8s_size`| string | OpenTelemetry collector storage size | False |
 | `public_url`| string | Public URL of Kubeflow for auth/OIDC | False |
 | `risk`| string | Value for the risk to be used | False |

--- a/modules/kubeflow/applications.tf
+++ b/modules/kubeflow/applications.tf
@@ -304,11 +304,9 @@ module "minio" {
 module "oidc_gatekeeper" {
   source     = "git::https://github.com/canonical/oidc-gatekeeper-operator//terraform?ref=main"
   model_name = var.create_model ? juju_model.kubeflow[0].name : local.model
-  config = {
-    ca-bundle = var.oidc_gatekeeper_ca_bundle,
-  }
-  revision = var.oidc_gatekeeper_revision
-  channel  = "${local.track}/${var.risk}"
+  config     = var.oidc_gatekeeper_config
+  revision   = var.oidc_gatekeeper_revision
+  channel    = "${local.track}/${var.risk}"
 }
 
 module "pvcviewer_operator" {

--- a/modules/kubeflow/variables.tf
+++ b/modules/kubeflow/variables.tf
@@ -173,10 +173,10 @@ variable "mlmd_size" {
   default     = "10G"
 }
 
-variable "oidc_gatekeeper_ca_bundle" {
-  description = "Custom CA to be trusted by OIDC gatekeeper"
-  type        = string
-  default     = ""
+variable "oidc_gatekeeper_config" {
+  description = "Config options for OIDC gatekeeper"
+  type        = map(string)
+  default     = {}
 }
 
 variable "no_proxy" {


### PR DESCRIPTION
Replace the separate oidc_gatekeeper_ca_bundle string variable with a generic oidc_gatekeeper_config map(string) to allow passing arbitrary charm configuration options.